### PR TITLE
Deregistration (and consultation rate)

### DIFF
--- a/analysis/dataset_definition_t2dm.py
+++ b/analysis/dataset_definition_t2dm.py
@@ -248,21 +248,21 @@ dataset.cov_bin_healthcare_worker = (
 )
 
 ## Consultation rate in previous year (mid2017 to mid2018) as a proxy for health seeking behaviour
-tmp_cov_num_consrate = appointments.where(
-    appointments.status.is_in([
-        "Arrived",
-        "In Progress",
-        "Finished",
-        "Visit",
-        "Waiting",
-        "Patient Walked Out",
-        ]) & appointments.start_date.is_on_or_between("2017-06-01", "2018-06-30")
-        ).count_for_patient()    
+#tmp_cov_num_consrate = appointments.where(
+#    appointments.status.is_in([
+#        "Arrived",
+#        "In Progress",
+#        "Finished",
+#        "Visit",
+#        "Waiting",
+#        "Patient Walked Out",
+#        ]) & appointments.start_date.is_on_or_between("2017-06-01", "2018-06-30")
+#        ).count_for_patient()    
 
-dataset.cov_num_consrate = case(
-    when(tmp_cov_num_consrate <= 365).then(tmp_cov_num_consrate),
-    otherwise=365, # quality assurance
-)
+#dataset.cov_num_consrate = case(
+#    when(tmp_cov_num_consrate <= 365).then(tmp_cov_num_consrate),
+#    otherwise=365, # quality assurance
+#)
 
 ## Obesity, on or before elig_date_t2dm
 dataset.cov_bin_obesity = (

--- a/analysis/table1.R
+++ b/analysis/table1.R
@@ -46,7 +46,7 @@ var_labels <- list(
   cov_cat_smoking_status ~ "Smoking status",
   cov_bin_carehome_status ~ "Care/nursing home resident",
   cov_bin_healthcare_worker ~ "Healthcare worker",
-  # cov_num_consrate ~ "Consultation rate in previous year",
+  cov_num_consrate ~ "Consultation rate in previous year",
   cov_bin_obesity ~ "Body Mass Index > 30 kg/m^2",
   cov_cat_hba1c_mmol_mol ~ "HbA1c categories in mmol/mol",
   cov_cat_tc_hdl_ratio ~ "TC/HDL ratio categories",

--- a/analysis/table1.R
+++ b/analysis/table1.R
@@ -46,7 +46,7 @@ var_labels <- list(
   cov_cat_smoking_status ~ "Smoking status",
   cov_bin_carehome_status ~ "Care/nursing home resident",
   cov_bin_healthcare_worker ~ "Healthcare worker",
-  cov_num_consrate ~ "Consultation rate in previous year",
+  #cov_num_consrate ~ "Consultation rate in previous year",
   cov_bin_obesity ~ "Body Mass Index > 30 kg/m^2",
   cov_cat_hba1c_mmol_mol ~ "HbA1c categories in mmol/mol",
   cov_cat_tc_hdl_ratio ~ "TC/HDL ratio categories",


### PR DESCRIPTION
Hi @ZoeMZou ,
This is a PR for the de-registration variable issue. Let me try to summarise:
* When looking at preliminary data we realized that we have more deregistrations within short span of time than expected
* This brought up the question what kind of deregistrations I am extracting from ehrQL, i.e., only deregistrations from TPP itself or deregistrations from different practices within TPP, when people move or when they have several registrations and stop one (e.g. a person has a registration in home town and in university/work town)
* As far as I understand, there is no direct ehrQL pendant to the former cohort extractor code [date_deregistered_from_all_supported_practices](https://docs.opensafely.org/legacy/study-def-variables/#cohortextractor.patients.date_deregistered_from_all_supported_practices)
* So, the [end_date](https://docs.opensafely.org/ehrql/reference/schemas/tpp/#practice_registrations.end_date) will capture all deregistrations from all (parallel) registrations. 
* However if we identify the most important registration at baseline, i.e. by using spanning back e.g. 1 year, then we know which registration is the "main registration".
* Then, my thinking is that we should only use deregistration from that "main registration" as our dereg_date, and ignore the other parallel deregistrations at other TPP practices, and that's what I tried to implement

Does that make sense?

PS: The consultation rate variable I took over from your post-covid respiratory repo - thanks a lot! But I still have to wait for permission from OpenSAFELY to use the appointments table.