### PR TITLE
Cox reusable action

### DIFF
--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -33,6 +33,7 @@ source(here::here("analysis", "functions", "fn_elig_criteria_midpoint6.R"))
 
 
 # Create directories for output -------------------------------------------
+fs::dir_create(here::here("output"))
 fs::dir_create(here::here("output", "data"))
 fs::dir_create(here::here("output", "data_description"))
 

--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -291,7 +291,7 @@ data_processed <- data_processed %>%
                                                      landmark_date,
                                                      units = "days") %>% as.numeric(),
     # for cox reusable action: exposure start date for those who start, missing for all others 
-    cox_date_metfin_start_within6m = case_when(exp_bin_metfin_mono == TRUE ~ landmark_date + days(1), 
+    cox_date_metfin_start_within6m = case_when(exp_bin_metfin_mono == TRUE ~ landmark_date, 
                                                TRUE ~ as.Date(NA))
   )
 

--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -33,7 +33,6 @@ source(here::here("analysis", "functions", "fn_elig_criteria_midpoint6.R"))
 
 
 # Create directories for output -------------------------------------------
-fs::dir_create(here::here("output"))
 fs::dir_create(here::here("output", "data"))
 fs::dir_create(here::here("output", "data_description"))
 
@@ -334,4 +333,3 @@ write.csv(n_elig_excluded_midpoint6, file = here::here("output", "data_descripti
 write.csv(n_elig_excluded, file = here::here("output", "data_description", "n_elig_excluded.csv"))
 # final (restricted) dataset
 arrow::write_feather(data_processed, here::here("output", "data", "data_processed.arrow"))
-arrow::write_feather(data_processed, here::here("output", "data_processed.arrow"))

--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -291,7 +291,7 @@ data_processed <- data_processed %>%
                                                      landmark_date,
                                                      units = "days") %>% as.numeric(),
     # for cox reusable action: exposure start date for those who start, missing for all others 
-    cox_date_metfin_start_within6m = case_when(exp_bin_metfin_mono == TRUE ~ landmark_date, 
+    cox_date_metfin_start_within6m = case_when(exp_bin_metfin_mono == TRUE ~ landmark_date + days(1), 
                                                TRUE ~ as.Date(NA))
   )
 
@@ -333,3 +333,4 @@ write.csv(n_elig_excluded_midpoint6, file = here::here("output", "data_descripti
 write.csv(n_elig_excluded, file = here::here("output", "data_description", "n_elig_excluded.csv"))
 # final (restricted) dataset
 arrow::write_feather(data_processed, here::here("output", "data", "data_processed.arrow"))
+arrow::write_feather(data_processed, here::here("output", "data_processed.arrow"))

--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -289,7 +289,10 @@ data_processed <- data_processed %>%
                                                    na.rm = TRUE),
     cox_tt_longcovid_virfat_afterlandmark = difftime(cox_date_longcovid_virfat_afterlandmark,
                                                      landmark_date,
-                                                     units = "days") %>% as.numeric()
+                                                     units = "days") %>% as.numeric(),
+    # for cox reusable action: exposure start date for those who start, missing for all others 
+    cox_date_metfin_start_within6m = case_when(exp_bin_metfin_mono == TRUE ~ landmark_date, 
+                                               TRUE ~ as.Date(NA))
   )
 
 

--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -82,7 +82,7 @@ data_processed <- data_extracted %>%
       cov_cat_ethnicity == "Other" ~ "Other",
       TRUE ~ "Unknown"),
     
-    strat_cat_region = fn_case_when(
+    cov_cat_region = fn_case_when(
       strat_cat_region == "East" ~ "East",
       strat_cat_region == "London" ~ "London",
       strat_cat_region %in% c("West Midlands", "East Midlands") ~ "Midlands",

--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -82,7 +82,7 @@ data_processed <- data_extracted %>%
       cov_cat_ethnicity == "Other" ~ "Other",
       TRUE ~ "Unknown"),
     
-    cov_cat_region = fn_case_when(
+    strat_cat_region = fn_case_when(
       strat_cat_region == "East" ~ "East",
       strat_cat_region == "London" ~ "London",
       strat_cat_region %in% c("West Midlands", "East Midlands") ~ "Midlands",

--- a/project.yaml
+++ b/project.yaml
@@ -69,7 +69,6 @@ actions:
       highly_sensitive:
         dataset1: output/data/data_processed.arrow
         dataset2: output/data/data_processed_full.arrow
-        dataset3: output/data_processed.arrow
       moderately_sensitive:
         flowchart_tbls: output/data_description/*.csv
 
@@ -118,9 +117,9 @@ actions:
         csv: output/te/cox_scripted/*.csv
   
   cox_primary_RA:
-    run: cox-ipw:v0.0.33
+    run: cox-ipw:v0.0.34
     config:
-     df_input: data_processed.arrow
+     df_input: data/data_processed.arrow
      ipw: FALSE
      exposure: cox_date_metfin_start_within6m
      outcome: out_date_severecovid_afterlandmark
@@ -132,7 +131,7 @@ actions:
      cox_stop: cox_date_severecovid
      study_start: "2018-07-01"
      study_stop: "2022-04-01"
-     cut_points: 28;90;365;730
+     cut_points: 730
      age_spline: TRUE
      save_analysis_ready: FALSE
      df_output: results_cox_ra.csv

--- a/project.yaml
+++ b/project.yaml
@@ -69,6 +69,7 @@ actions:
       highly_sensitive:
         dataset1: output/data/data_processed.arrow
         dataset2: output/data/data_processed_full.arrow
+        dataset3: output/data_processed.arrow
       moderately_sensitive:
         flowchart_tbls: output/data_description/*.csv
 

--- a/project.yaml
+++ b/project.yaml
@@ -117,13 +117,13 @@ actions:
         csv: output/te/cox_scripted/*.csv
   
   cox_primary_RA:
-    run: cox-ipw:v0.0.34
+    run: cox-ipw:v0.0.36
     config:
      df_input: data/data_processed.arrow
      ipw: FALSE
      exposure: cox_date_metfin_start_within6m
      outcome: out_date_severecovid_afterlandmark
-     strata: cov_cat_region
+     strata: strat_cat_region
      covariate_sex: cov_cat_sex
      covariate_age: cov_num_age
      covariate_other: cov_cat_ethnicity;cov_cat_deprivation_5;cov_cat_rural_urban;cov_cat_smoking_status;cov_bin_carehome_status;cov_bin_healthcare_worker;cov_bin_obesity;cov_bin_ami;cov_bin_all_stroke;cov_bin_other_arterial_embolism;cov_bin_vte;cov_bin_hf;cov_bin_angina;cov_bin_dementia;cov_bin_cancer;cov_bin_hypertension;cov_bin_depression;cov_bin_copd;cov_bin_liver_disease;cov_bin_chronic_kidney_disease;cov_bin_pcos;cov_bin_prediabetes;cov_bin_diabetescomp;cov_cat_tc_hdl_ratio;cov_cat_hba1c_mmol_mol

--- a/project.yaml
+++ b/project.yaml
@@ -123,7 +123,7 @@ actions:
      ipw: FALSE
      exposure: cox_date_metfin_start_within6m
      outcome: out_date_severecovid_afterlandmark
-     strata: strat_cat_region
+     strata: cov_cat_region
      covariate_sex: cov_cat_sex
      covariate_age: cov_num_age
      covariate_other: cov_cat_ethnicity;cov_cat_deprivation_5;cov_cat_rural_urban;cov_cat_smoking_status;cov_bin_carehome_status;cov_bin_healthcare_worker;cov_bin_obesity;cov_bin_ami;cov_bin_all_stroke;cov_bin_other_arterial_embolism;cov_bin_vte;cov_bin_hf;cov_bin_angina;cov_bin_dementia;cov_bin_cancer;cov_bin_hypertension;cov_bin_depression;cov_bin_copd;cov_bin_liver_disease;cov_bin_chronic_kidney_disease;cov_bin_pcos;cov_bin_prediabetes;cov_bin_diabetescomp;cov_cat_tc_hdl_ratio;cov_cat_hba1c_mmol_mol

--- a/project.yaml
+++ b/project.yaml
@@ -116,7 +116,31 @@ actions:
       moderately_sensitive:
         csv: output/te/cox_scripted/*.csv
   
-
+  cox_primary_RA:
+    run: cox-ipw:v0.0.33
+    config:
+     df_input: data_processed.arrow
+     ipw: FALSE
+     exposure: cox_date_metfin_start_within6m
+     outcome: out_date_severecovid_afterlandmark
+     strata: cov_cat_region
+     covariate_sex: cov_cat_sex
+     covariate_age: cov_num_age
+     covariate_other: cov_cat_ethnicity;cov_cat_deprivation_5;cov_cat_rural_urban;cov_cat_smoking_status;cov_bin_carehome_status;cov_bin_healthcare_worker;cov_bin_obesity;cov_bin_ami;cov_bin_all_stroke;cov_bin_other_arterial_embolism;cov_bin_vte;cov_bin_hf;cov_bin_angina;cov_bin_dementia;cov_bin_cancer;cov_bin_hypertension;cov_bin_depression;cov_bin_copd;cov_bin_liver_disease;cov_bin_chronic_kidney_disease;cov_bin_pcos;cov_bin_prediabetes;cov_bin_diabetescomp;cov_cat_tc_hdl_ratio;cov_cat_hba1c_mmol_mol
+     cox_start: landmark_date
+     cox_stop: cox_date_severecovid
+     study_start: "2018-07-01"
+     study_stop: "2022-04-01"
+     cut_points: 28;90;365;730
+     age_spline: TRUE
+     save_analysis_ready: FALSE
+     df_output: results_cox_ra.csv
+    needs:
+    - data_process
+    outputs:
+      moderately_sensitive:
+        arguments: output/args-results_cox_ra.csv
+        estimates: output/results_cox_ra.csv
 
   
   # km_estimates_metfin_RA:

--- a/project.yaml
+++ b/project.yaml
@@ -116,6 +116,28 @@ actions:
       moderately_sensitive:
         csv: output/te/cox_scripted/*.csv
   
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
   cox_primary_RA:
     run: cox-ipw:v0.0.36
     config:
@@ -142,7 +164,7 @@ actions:
         arguments: output/args-results_cox_ra.csv
         estimates: output/results_cox_ra.csv
 
-  
+
   # km_estimates_metfin_RA:
   #   run: kaplan-meier-function:v0.0.8
   #     --df_input=output/data/data_plots.feather

--- a/project.yaml
+++ b/project.yaml
@@ -123,7 +123,7 @@ actions:
      ipw: FALSE
      exposure: cox_date_metfin_start_within6m
      outcome: out_date_severecovid_afterlandmark
-     strata: cov_cat_region
+     strata: strat_cat_region
      covariate_sex: cov_cat_sex
      covariate_age: cov_num_age
      covariate_other: cov_cat_ethnicity;cov_cat_deprivation_5;cov_cat_rural_urban;cov_cat_smoking_status;cov_bin_carehome_status;cov_bin_healthcare_worker;cov_bin_obesity;cov_bin_ami;cov_bin_all_stroke;cov_bin_other_arterial_embolism;cov_bin_vte;cov_bin_hf;cov_bin_angina;cov_bin_dementia;cov_bin_cancer;cov_bin_hypertension;cov_bin_depression;cov_bin_copd;cov_bin_liver_disease;cov_bin_chronic_kidney_disease;cov_bin_pcos;cov_bin_prediabetes;cov_bin_diabetescomp;cov_cat_tc_hdl_ratio;cov_cat_hba1c_mmol_mol


### PR DESCRIPTION
Hi @venexia,
May I send you this PR? It's what we looked at together during the meeting - but one addition which we did not discuss:
- `cox_date_metfin_start_within6m` , see variable definition in `data_process.R`. 
- `landmark_date` is my input for the cox_start argument and is complete for all participants, defined as six months after type 2 diabetes diagnosis (`elig_date_t2dm`), the date of eligibility. Because of the landmark design, we disregard the first six months, only start follow-up then with everyone who is still alive and not LTFU at that point. 
- `cox_date_metfin_start_within6m` is only complete for those in intervention, i.e. started metformin mono during the first six months, but their exposure date should be reset to the landmark date. 
- Now, doing simply: cox_date_metfin_start_within6m = case_when(exp_bin_metfin_mono == TRUE ~ landmark_date, TRUE ~ as.Date(NA)) throws the following error: 

![Screenshot 2025-04-03 at 15 51 42](https://github.com/user-attachments/assets/1fd43d12-3a93-4785-a1a7-f94ffeb2c1e1)

Seems like an issue with some date overlap between landmark and exposure dates. If I add 1 day, it works - but probably not the cleanest workaround...if you have some insights regarding the error and suggestion for a better workaround, I'd be very glad! 

Thanks a lot!