### PR TITLE
(de)registration variable

### DIFF
--- a/analysis/dataset_definition_t2dm.py
+++ b/analysis/dataset_definition_t2dm.py
@@ -202,7 +202,6 @@ dataset.cov_cat_deprivation_5 = case(
 # but use a mix between spanning (as per eligibility criteria) and for_patient_on() to sort the multiple rows: https://docs.opensafely.org/ehrql/reference/schemas/tpp/#practice_registrations.for_patient_on
 spanning_regs = practice_registrations.spanning(dataset.elig_date_t2dm - days(366), dataset.elig_date_t2dm)
 registered = spanning_regs.sort_by(
-    practice_registrations.start_date,
     practice_registrations.end_date,
     practice_registrations.practice_pseudo_id,
 ).last_for_patient()
@@ -475,12 +474,7 @@ dataset.out_date_longcovid_virfat = minimum_of(dataset.out_date_longcovid, datas
 ### UPDATED eligibility and intercurrent events for potential censoring
 ## Practice deregistration date: Based on main registration at t2dm diagnosis date
 # However, it does count those who only switch TPP practices
-deregistered = spanning_regs.sort_by(
-practice_registrations.end_date,
-practice_registrations.practice_pseudo_id,
-).last_for_patient()
-
-dataset.cens_date_dereg = deregistered.end_date
+dataset.cens_date_dereg = registered.end_date
 
 ## Known hypersensitivity / intolerance to metformin, on or before elig_date_t2dm
 dataset.cens_date_metfin_allergy_first = first_matching_event_clinical_snomed_between(metformin_allergy_snomed_clinical, dataset.elig_date_t2dm + days(1), studyend_date).date


### PR DESCRIPTION
based on Zoe's input/discussion:

"Hi,
That makes sense to me. Thank you very much for your clarification. I actually had several conversations with OpenSAFELY engineers about deregistration at the last conference, and your understanding aligns with what they explained.
Just to add some context—according to them, parallel practice registrations in the real data are extremely rare and considered negligible in terms of influence. Based on this, they recommended using only one registration span:
- If a registration spans the entire study period of interest, then there is no deregistration.
- If it does not, even if another registration at a different practice starts immediately after the first one ends within the study period, we should still count it as a deregistration. This is because, during any gap (even a very short one), we cannot determine whether the person left TPP entirely or simply moved between practices within TPP.
This approach helps balance the risk of losing information for patients who may have deregistered from TPP entirely versus those who simply switched practices within TPP. It is difficult to assume that all observed deregistrations are just transfers between TPP practices (where no information is lost) rather than exits from TPP and later re-entries (where diagnoses and other events could be missing).
I assume by "main registration" you mean the latest registered date before the study start date and whether that span includes a deregistration within the study period. If so, when?
Let me know if this interpretation aligns with your implementation!
Best,
Zoe"