### PR TITLE
Per protocol analysis using pooled log reg based on discretized person-time

### DIFF
--- a/analysis/PPA_01_add_intervals.R
+++ b/analysis/PPA_01_add_intervals.R
@@ -1,0 +1,91 @@
+####
+## This script does the following:
+# 1. Import pre-processed data of a one-person-per-row dataset of eligible participants (data_processed.arrow)
+# 2. Restructure the one-person-per-row data into a multiple-event-per-person long format dataset, with time intervals as per study protocol
+# 3. Save dataset(s)
+####
+
+
+# Import libraries and functions ------------------------------------------
+print('Import libraries and functions')
+library(arrow)
+library(here)
+library(tidyverse)
+library(lubridate) # for fn_expand_intervals.R
+library(rlang) # for fn_expand_intervals.R
+source(here::here("analysis", "functions", "fn_expand_intervals.R"))
+
+
+# Create directories for output -------------------------------------------
+print('Create directories for output')
+fs::dir_create(here::here("output", "data"))
+
+
+# Import the data ---------------------------------------------------------
+print('Import the data')
+df <- read_feather(here("output", "data", "data_processed.arrow"))
+
+
+# Import dates ------------------------------------------------------------
+print('Import dates')
+source(here::here("analysis", "metadates.R"))
+study_dates <- lapply(study_dates, function(x) as.Date(x))
+studyend_date <- as.Date(study_dates$studyend_date, format = "%Y-%m-%d")
+
+
+# Filter main dataset for PLR pipeline: Only keep necessary variables -----
+df <- df %>% 
+  select(patient_id, 
+         elig_date_t2dm, 
+         landmark_date,
+         exp_bin_treat,
+         starts_with("strat_"), # Stratification variable
+         starts_with("cov_"), # Covariates
+         starts_with("out_"), # Outcomes
+         starts_with("cens_") # Censoring variable
+  )
+
+
+# Expand the dataset ------------------------------------------------------
+print('Expand the dataset')
+# (1) Define the interval: In this scenario, we use monthly intervals, balance between how much is happening in a given interval vs granularity vs computational
+# (2) Define the dataset stopping events: We will expand the dataset until 
+## a. any death (out_date_death_afterlandmark), 
+## b. deregistration from TPP (cens_date_ltfu_afterlandmark), 
+## c. end of study (studyend_date = 01.04.2022)
+# (3) Our outcomes of interest: 
+## a. out_date_severecovid_afterlandmark (includes covid deaths): Primary outcome
+## b. out_date_noncoviddeath_afterlandmark: Competing event. In primary analysis, we simply treat it as censoring event ("controlled direct effect")
+#### Side note re competing event: We may - at a later stage - consider targeting a "total effect" (by assigning outcome == 0 for everyone who had a non-covid death and including their follow-up time after non-covid deaths, i.e. not censoring them)
+## c. cens_date_ltfu_afterlandmark: Censoring event. We may want to upweigh those who were not censored using a hypothetical treatment strategy for this intercurrent event ("assume no-one is LTFU") 
+## d. cens_date_metfin_start_cont: Censoring event for the per-protocol analysis ONLY. We will upweigh those who did not start metformin in control group, using a hypothetical treatment strategy for this intercurrent event ("assume no-one started metformin in control")
+## e. out_date_covid_afterlandmark: Secondary outcome (includes covid tests, diagnoses, hosp & deaths). All other competing/censoring events same as above.
+## f. out_date_longcovid_virfat_afterlandmark: Secondary outcome (includes viral fatigue and long covid codes). All other competing/censoring events same as above, except we use all-cause death as competing event: 
+## g. out_date_death_afterlandmark: All-cause mortality, the competing event variable only for analysis of the secondary endpoint Long covid.
+
+# Apply the interval expansion function
+## CAVE: All stop_date_columns dates must be AFTER start_date_variable
+## CAVE: only choose stopping events that are distinct and overarching (e.g. all-cause death instead of cause-specific deaths or overlapping outcomes)
+df_months <- fn_expand_intervals(df, 
+                                 start_date_variable = "landmark_date", # start expanding from landmark date, not elig_date_t2dm (due to landmark design)
+                                 stop_date_columns = c("out_date_death_afterlandmark", "cens_date_ltfu_afterlandmark"),
+                                 studyend_date,
+                                 interval_type = "month") # currently, function takes "month" or "week"
+## NOTE: the function will add the final interval, even if the final interval is just 1 day (check stop_date == 2022-04-01)
+
+# To double-check
+# df_months %>%
+#   dplyr::select(patient_id, elig_date_t2dm, landmark_date, out_date_severecovid_afterlandmark, out_date_death_afterlandmark,
+#                 cens_date_ltfu_afterlandmark, stop_date, start_date_month, end_date_month, month,
+#                 cov_cat_sex, cov_num_age
+#   ) %>%
+#   dplyr::filter(!is.na(out_date_death_afterlandmark)) %>%
+#   # dplyr::filter(!is.na(cens_date_ltfu_afterlandmark)) %>%
+#   # dplyr::filter(stop_date == "2022-04-01") %>%
+#   View()
+
+
+# Save output -------------------------------------------------------------
+print('Save output')
+# Save long format dataset
+arrow::write_feather(df_months, here::here("output", "data", "df_months.arrow"))

--- a/analysis/PPA_02_add_events.R
+++ b/analysis/PPA_02_add_events.R
@@ -1,0 +1,509 @@
+####
+## This script does the following:
+# 1. Import multiple-event-per-person long format dataset (df_months, which originates from data_processed.arrow)
+# 2. Import the additional dataset with stable and dynamic time-updated covariates needed for the per-protocol analysis (data_processed_ppa.arrow -> df_ppa)
+# 3. Assign treatment to df_months
+# 4. Merge the stable time-updated (first-ever, constant) covariates from df_ppa to df_months. To test edge cases, further adapt dummy data.
+# 5. Assign the stable time-updated (first-ever, constant) in df_months. 
+# 6. Reformatting of the dynamic time-updated covariates in a long-format df_ppa, before merging to df_months. To test edge cases, further adapt dummy data.
+# 7. Merge and assign the dynamic time-updated covariates covariates from df_ppa to df_months. To test edge cases, further adapt dummy data.
+# 8. Fill up the Swiss cheese and reassign the lipid ratio.
+# 9. Assign and shift outcomes, competing, and censoring events
+# 10. Define eligibility
+# 11. Save datasets
+####
+
+
+# Import libraries and functions ------------------------------------------
+print('Import libraries and functions')
+library(arrow)
+library(here)
+library(tidyverse)
+library(zoo) # for fn_assign_stable_tu_cov.R
+
+source(here::here("analysis", "functions", "fn_assign_treatment.R"))
+source(here::here("analysis", "functions", "fn_assign_stable_tu_cov.R"))
+source(here::here("analysis", "functions", "fn_assign_dynamic_tu_cov.R"))
+source(here::here("analysis", "functions", "fn_add_and_shift_out_comp_cens_events.R"))
+
+
+# Create directories for output -------------------------------------------
+print('Create directories for output')
+fs::dir_create(here::here("output", "data"))
+
+
+# Import dates ------------------------------------------------------------
+print('Import dates')
+source(here::here("analysis", "metadates.R"))
+study_dates <- lapply(study_dates, function(x) as.Date(x))
+studyend_date <- as.Date(study_dates$studyend_date, format = "%Y-%m-%d")
+
+
+# 1 + 2. Import the data ---------------------------------------------------------
+print('Import the data')
+df_months <- read_feather(here("output", "data", "df_months.arrow"))
+df_ppa <- read_feather(here("output", "data", "data_processed_ppa.arrow")) 
+
+
+# 3. Assign treatment to df_months -------------------------------------------
+print('Assign treatment to df_months')
+## Definition: Assign treatment status in interval k based on the latest treatment initiation recorded within that same interval. 
+## Rationale: Treatment is the focal point of each interval; no lagging or leading is necessary for its definition.
+
+### Moreover, we assume someone stays on treatment once is initiated, i.e., first-ever, time-fixed event 
+### Moreover, here, we have defined treatment at baseline already (exp_bin_treat), we only assign treatment in control to flag those who initiate during follow-up (cens_date_metfin_start_cont)
+### I can use my preexisting function, which works perfectly for this, based on these rules:
+# a) if event date is not NA and happened before the minimum start date of all intervals of a person, then assign 1 (in corresponding flag variable) to all person-intervals
+# b) if event date is not NA and happened after the maximum end date of all intervals of a person, then assign 0 (in corresponding flag variable) to all person-intervals
+# c) if no event date is recorded (date variable == NA), then assign 0 (in corresponding flag variable) to all person-intervals (assuming no documentation = no event)
+# d) if event date happened during follow-up, then assign 1 (in corresponding flag variable) to corresponding person-interval, and 0 to all person-intervals before, and 1 to all person-intervals after (stable/time-fixed event)
+date_treat_vars <- c("cens_date_metfin_start_cont")
+df_months <- fn_assign_treatment(df_months, 
+                                 date_treat_vars,
+                                 start_var = "start_date_month", 
+                                 end_var = "end_date_month")
+# To double-check
+# df_months %>%
+#   dplyr::select(patient_id, elig_date_t2dm, landmark_date, month, start_date_month, end_date_month,
+#                 exp_bin_treat, cens_date_metfin_start_cont, cens_bin_metfin_start_cont,
+#                 out_date_severecovid_afterlandmark, out_date_death_afterlandmark,
+#                 cens_date_ltfu_afterlandmark,
+#                 cov_cat_sex, cov_num_age
+#   ) %>%
+#   # dplyr::filter(exp_bin_treat == 0) %>%
+#   # dplyr::filter(cens_bin_metfin_start_cont == 1)
+#   View()
+
+# cens_bin_metfin_start_cont is now the corresponding flag variable for treatment start in control group
+
+
+# There are two types of time-updated covariates:
+## a) stable time-updated (first-ever, constant) covariates: E.g. new stroke diagnosis, or new CKD diagnosis during follow-up
+### These are stable over time, we only track the first ever occurring and then a person has it -> "0" in before the event, "1" after it happened
+### These are simple to assign, do not require a long-format (event-level) dataset, and (in our case) make up a big share of the time-updated covariates
+### Hence, deal with them first in a simple and efficient way
+## b) dynamic time-update covariates: E.g. Hba1c, BMI, lipids (of course something like smoking could feature here as well, we ignore this for now)
+### These are dynamic over time, may increase/decrease, in the person-interval dataset we carry over the last value until something new is happening
+### These are more complex to assign, we need event-level dataset and work with them in a long format dataset until we have reduced them to 1 measurement (the correct one! see rules) per person/interval
+### Once done, we merge them to the main person-month dataset with all other variables. But work on them in a separate long format dataset for as long as possible to be efficient.
+
+
+# 4. Merge the stable time-updated (first-ever, constant) covariates from df_ppa to df_months --------
+print('Merge the stable time-updated (first-ever, constant) covariates from df_ppa to df_months')
+# all covariates from df_ppa, except hba1c/lipids/bmi
+# it will result in a dataset with "cov_bin_* (comorbidities)" as baseline indicators and "cov_date_* (comorbidities)" for the stable one-time time-updated (first-ever, constant) covariate
+# Ignore the "cov_bin_* (comorbidities)" from df_months since "cov_date_* (comorbidities)" from df_ppa was constructed as minimmum of first ever (see dataset_definition_ppa.py). It would have been cleaner to do this directly in df_months - if we would have know about the PPA from the start.
+df_months <- df_months %>%
+  left_join(df_ppa %>% 
+              select(patient_id, starts_with("cov_date") & !matches("cov_date_bmi|cov_date_hba1c|cov_date_hdl_chol|cov_date_chol")),
+            by = "patient_id"
+            )
+
+# Modify dummy data
+## This script modifies dummy data of df_months to: 
+## - randomly select 50% of cov_date_ami 
+## - change them to be very close to the treatment information change, i.e., cens_date_metfin_start_cont (within 5 days before/after cens_date_metfin_start_cont)
+## - this will test edge cases for fn_assign_time_fixed_cov
+print('Modify dummy data')
+if (Sys.getenv("OPENSAFELY_BACKEND") %in% c("", "expectations")) {
+  message("Running locally, adapt dummy data")
+  source("analysis/PPA_modify_dummy_data_df_months.R")
+  message("Dummy data successfully modified")
+}
+
+
+# 5. Assign the stable time-updated (first-ever, constant) covariates --------
+print('Assign the stable time-updated (first-ever, constant) covariates')
+## Definition: Assign covariate status for interval k using latest covariate information before treatment status in interval k. 
+## If no covariate status update before treatment status in interval k or no treatment status update, then carry over the latest covariate information from interval k−1.
+## Rationale: This ensures that covariate information temporally precedes treatment assignment and in general reflects the latest available information at the start of interval k.
+
+### Use a function with the following rules:
+# First step:
+# a) if covariate date (e.g. cov_date_ami) is not NA and happened before the minimum start date of all intervals of a person, then assign 1 (in corresponding flag variable) to all person-intervals
+# b) if covariate date is not NA and happened after the maximum end date of all intervals of a person, then assign 0 (in corresponding flag variable) to all person-intervals
+# c) if covariate date is NA, then assign 0 (in corresponding flag variable) to all person-intervals (assuming no documentation = no event)
+# d) if covariate date is a date that happened during follow-up, then assign 1 (in flag variable) to next person-interval (using lag), 0 to all person-intervals before (incl. the current person-interval), and 1 to all person-intervals after (stable/time-fixed event)
+## CAVE: This will now overwrite the preexisting cov_bin_ variables from the main dataset, which is fine (see comment above), but just to be aware of
+# Second step:
+# e) if covariate date is a date that happened during follow-up, check if this date is in same interval as the censoring event (cens_date_metfin_start_cont, i.e. started treatment in control group) and 
+# if it happened on or before cens_date_metfin_start_cont, then assign 1 (in cov flag variable) to the current (not only next) person-interval. Otherwise, keep all as it is.
+
+date_stable_tu_vars <- c("cov_date_ami",
+                      "cov_date_hypertension",
+                      "cov_date_all_stroke", "cov_date_other_arterial_embolism",
+                      "cov_date_vte", "cov_date_hf", "cov_date_angina", "cov_date_dementia",
+                      "cov_date_cancer", "cov_date_depression",
+                      "cov_date_copd", "cov_date_liver_disease", "cov_date_chronic_kidney_disease",
+                      "cov_date_pcos", "cov_date_prediabetes","cov_date_diabetescomp"
+                      )
+df_months <- fn_assign_stable_tu_cov(df_months, 
+                                     date_stable_tu_vars,
+                                     start_var = "start_date_month", 
+                                     end_var = "end_date_month",
+                                     cens_date_var = "cens_date_metfin_start_cont")
+
+# To double-check
+# df_months %>%
+#   dplyr::select(patient_id, elig_date_t2dm, landmark_date, month, start_date_month, end_date_month,
+#                 exp_bin_treat, cens_date_metfin_start_cont, cens_bin_metfin_start_cont,
+#                 cov_date_ami, cov_bin_ami,
+#                 cov_date_hypertension, cov_bin_hypertension,
+#                 cov_date_all_stroke, cov_bin_all_stroke,
+#                 # cov_date, min_start, max_end, event_here, cov_flag_temp
+#   ) %>%
+#   dplyr::filter(!is.na(cov_date_ami)) %>%
+#   dplyr::filter(!is.na(cens_date_metfin_start_cont)) %>%
+#   View()
+
+
+# 6. Reformatting of the dynamic time-updated covariates in a long-format df_ppa ---------
+print('Reformatting of the dynamic time-updated covariates in a long-format df_ppa')
+# The aim is to get a one-person-per-row dataset that we can merge to the main dataset
+# So first, we work with df_ppa separately, merging to df_months only at the end; this avoids unnecessary creating/working with the main df_months as a long-format dataset (computational issues)
+
+# Filter all dynamic time-updated covariates: hba1c/lipids/bmi
+df_ppa <- df_ppa %>%
+  select(patient_id, matches("_bmi_|_hba1c_|_chol_|_hdl_chol_"))
+df_treat <- df_months %>% 
+  filter(month == 0) %>% 
+  select(patient_id, cens_date_metfin_start_cont)
+# merge the cens_date_metfin_start_cont from df_months to adjust the dummy dates
+# if there are patient_id that are in df_ppa but not in df_month (df_treat), then ignore these. Should not be the case in the real data, but is the case in the dummy data due to how the @table_from_file function works
+df_ppa <- right_join(df_ppa, df_treat[, c("cens_date_metfin_start_cont", "patient_id")], by = "patient_id")
+
+# Reshape to long format, easier to work with
+df_ppa_long <- df_ppa %>%
+  pivot_longer(
+    cols = c(-patient_id, -cens_date_metfin_start_cont),
+    names_to = c(".value", "variable", "instance"),
+    names_pattern = "cov_(date|num)_([a-z0-9_]+)_(\\d+)",
+    values_drop_na = TRUE
+  )
+df_ppa_long <- df_ppa_long %>% filter(!is.na(num) & !is.na(date))
+df_ppa_long <- df_ppa_long %>% arrange(patient_id, variable, date)
+
+# Modify dummy data
+## This script modifies dummy data of df_ppa_long to: 
+## - randomly select 5% of "date" (which is the date variable for all measurements in df_ppa_long)
+## - change them to be very close to cens_date_metfin_start_cont (within 3 days before/after cens_date_metfin_start_cont)
+## - this will test edge cases
+print('Modify dummy data')
+if (Sys.getenv("OPENSAFELY_BACKEND") %in% c("", "expectations")) {
+  message("Running locally, adapt dummy data")
+  source("analysis/PPA_modify_dummy_data_df_ppa_long.R")
+  message("Dummy data successfully modified")
+}
+df_ppa_long <- df_ppa_long %>%
+  select(!cens_date_metfin_start_cont)
+
+# Perform the non-equi join with df_months to attach the num values from df_ppa to the correct monthly intervals from df_months, while still working in a reduced dataset
+df_ppa_long <- df_ppa_long %>%
+  # left_join to keep all rows=months from df_months => allow for many-to-many relationship
+  left_join(df_months, by = "patient_id") %>%
+  filter(
+    date >= start_date_month, # left open, right open is correct the way the interval data is set up coming from fn_expand_intervals.R
+    date <= end_date_month
+  ) %>%
+  select(
+    patient_id,
+    month,
+    start_date_month,
+    end_date_month,
+    variable,
+    date,
+    num,
+    cens_date_metfin_start_cont
+  )
+df_ppa_long <- df_ppa_long %>% arrange(patient_id, variable, date)
+
+# Now, if there are several of the same dynamic time-updated covariate events happening in the same interval/month (e.g. HbA1c several times recorded/measured in same month):
+## => carefully choose the relevant one, according to the following rules, taking our treatment information change/update variable (cens_date_metfin_start_cont) into account: 
+### a) If cov_date is in same interval as cens_date_metfin_start_cont and cov_date > cens_date_metfin_start_cont, then flag the one closest to end_date_month to be moved to the next month (and discard the others that are in same interval as cens_date_metfin_start_cont & with cov_date > cens_date_metfin_start_cont)
+### b) If cov_date is in same interval as cens_date_metfin_start_cont and cov_date <= cens_date_metfin_start_cont, then flag the one on or closest to cens_date_metfin_start_cont to keep (and discard the others that are also in same interval as cens_date_metfin_start_cont & cov_date <= cens_date_metfin_start_cont)
+#### If at the same time, there were also cov_date > cens_date_metfin_start_cont in same interval, they will have been dealt with in rule (a) already
+### c) If cov_date is not in same interval as cens_date_metfin_start_cont, then flag the one closest to end_date_month to be moved to the next month (and discard all others)
+### d) Then, shift all covariate info flagged as "move" to the next month, while keeping all flagged as "keep" in the original month
+
+##### Then, deal with edge cases: 
+### (i) We may have months whereby we moved a covariate due to rule (c) or rule (a) into a month with a "keep" covariate (rule b) => >1 covariate info update in same person-interval
+#### => Solution: "keep" beats "move", i.e., the one that was flagged as "keep" (because it contains time-update covariate info JUST before treatment change) is more important and wins
+##### Side-note: In our case, we only have treatment update once, so a move due to rule (a) ending up in a month with a "keep" covariate (rule b) is not possible - but the function/rules work with more complex dynamic treatment updates, too!
+### (ii) We may have the scenario whereby treatment update info and covariate update info change on same date (and no time-stamp to differentiate)
+#### => Solution: Regard these covariate info as measured BEFORE treatment info change (see rule b above). Alternatively (sensitivity analyses), simply adapt rule a and b to regard them as measured AFTER treatment info change
+
+##### At the end, this results in only 1 covariate info update per person-interval for each measurement (BMI, lipids, HbA1c)
+df_ppa_long <- fn_assign_dynamic_tu_cov(data = df_ppa_long,
+                                         patient_id_col = patient_id,
+                                         variable_col = variable,
+                                         date_col = date,
+                                         treat_date_col = cens_date_metfin_start_cont,
+                                         month_col = month,
+                                         start_date_col = start_date_month,
+                                         end_date_col = end_date_month)
+
+# To double-check
+dupl_same_id_variable_month <- df_ppa_long %>%
+  group_by(patient_id, variable, new_month) %>%
+  add_count(name = "count") %>%
+  filter(count > 1) %>%
+  arrange(patient_id, variable, new_month)
+print(dupl_same_id_variable_month) # should be empty
+
+# Now, pivot it to wide format to have the individual measurements as separate columns to be able to merge with df_months
+df_ppa_wide <- df_ppa_long %>%
+  group_by(patient_id, new_month, variable) %>%
+  mutate(instance = row_number()) %>%
+  ungroup() %>%
+  # The instance column ensures that each measurement gets its own row (i.e. if there are several measurements of the same measure in the same month)
+  # We need to remove start_date_month, end_date_month, otherwise it creates two rows (because the dates can now be different, we rely solely on new_month!)
+  pivot_wider(
+    id_cols = c(patient_id, new_month, cens_date_metfin_start_cont, instance),
+    names_from = variable,
+    values_from = c(date, num),
+    names_glue = "cov_{.value}_{variable}"
+  ) %>%
+  select(-instance) %>%
+  arrange(patient_id, new_month)
+
+duplicates_in_final <- df_ppa_wide %>%
+  group_by(patient_id, new_month) %>%
+  add_count(name = "count") %>%
+  filter(count > 1) %>%
+  ungroup()
+print(duplicates_in_final) # should be empty
+
+
+# 7. Merge and assign the dynamic time-updated covariates from df_ppa to df_months --------
+print('Merge and assign the dynamic time-updated covariates covariates from df_ppa to df_months')
+df_ppa_wide <- df_ppa_wide %>%
+  rename(month = new_month)
+df_ppa_wide <- df_ppa_wide %>%
+  select(!cens_date_metfin_start_cont) # take out the cens_date (otherwise, duplicate variables)
+
+# CAVE: due to new_month, it could be that we reach beyond max follow-up => ignore such rows for merging
+df_months <- df_months %>%
+  # Keep all df_months months; if there is a month in df_ppa_wide that is not in df_months do not include it. 
+  left_join(df_ppa_wide, by = c("patient_id", "month"))
+
+
+# 8. Fill up the Swiss cheese and reassign the lipid ratio --------
+print('Fill up the Swiss cheese and reassign the lipid ratio')
+tv_cov_num_cols <- c("cov_num_bmi", "cov_num_hba1c", "cov_num_chol", "cov_num_hdl_chol")
+baseline_lookup <- c(
+  cov_num_bmi = "cov_num_bmi_b",
+  cov_num_hba1c = "cov_num_hba1c_b",
+  cov_num_chol = "cov_num_chol_b",
+  cov_num_hdl_chol = "cov_num_hdl_chol_b"
+)
+
+df_months <- df_months %>%
+  group_by(patient_id) %>%
+  arrange(start_date_month, .by_group = TRUE) %>%
+  mutate(across(all_of(tv_cov_num_cols), 
+                .fns = ~ {
+                  baseline_col <- baseline_lookup[[cur_column()]]
+                  base_val <- cur_data()[[baseline_col]][1]
+                  
+                  first_non_na <- which(!is.na(.x))[1]
+                  
+                  if (is.na(first_non_na)) {
+                    # no observed values
+                    if (!is.na(base_val)) {
+                      # use baseline if available
+                      rep(base_val, length(.x))
+                    } else {
+                      # leave all NA
+                      .x
+                    }
+                  } else {
+                    # mask before first non-NA
+                    masked <- .x
+                    if (!is.na(base_val)) {
+                      masked[1:(first_non_na - 1)] <- base_val
+                    } else {
+                      masked[1:(first_non_na - 1)] <- NA
+                    }
+                    
+                    # forward fill
+                    tidyr::fill(data.frame(masked), masked, .direction = "down")$masked
+                  }
+                })) %>%
+  ungroup()
+
+# recreate the lipid ratio, HbA1c cat, and BMI cat (based on the monthly filled up values)
+df_months <- df_months %>%
+  mutate(
+    # See data_process.R
+    cov_num_chol = if_else(
+      cov_num_chol > 20 | cov_num_chol < 1.75,
+      NA_real_,
+      cov_num_chol),
+    cov_num_hdl_chol = if_else(
+      cov_num_hdl_chol > 5 | cov_num_hdl_chol < 0.4,
+      NA_real_,
+      cov_num_hdl_chol),
+    cov_num_tc_hdl_ratio = cov_num_chol / cov_num_hdl_chol, # also overwrites the baseline value
+    cov_num_tc_hdl_ratio = if_else(
+      cov_num_tc_hdl_ratio > 50 | cov_num_tc_hdl_ratio < 1,
+      NA_real_,
+      cov_num_tc_hdl_ratio),
+    cov_cat_tc_hdl_ratio = cut(
+      cov_num_tc_hdl_ratio,
+      breaks = c(1, 3.5, 5.11, 50),  # 50 is upper limit, above set to NA already
+      labels = c("below 3.5:1" ,"3.5:1 to 5:1", "above 5:1"),
+      right = FALSE) %>% 
+      forcats::fct_expand("Unknown"),
+    cov_cat_tc_hdl_ratio = case_when(is.na(cov_cat_tc_hdl_ratio) ~ factor("Unknown", 
+                                                                          levels = c("below 3.5:1", "3.5:1 to 5:1", "above 5:1", "Unknown")), TRUE ~ cov_cat_tc_hdl_ratio)
+  ) %>% 
+  mutate(
+    # See data_process.R
+    cov_num_hba1c = if_else( 
+      cov_num_hba1c < 0.00 | cov_num_hba1c > 120.00,
+      NA_real_,
+      cov_num_hba1c), # also overwrites the baseline value
+    cov_cat_hba1c = cut(
+      cov_num_hba1c,
+      breaks = c(0, 42, 59, 76, 120), # 120 is upper limit, above NA
+      labels = c("below 42" ,"42-58", "59-75", "above 75"),
+      right = FALSE) %>% 
+      forcats::fct_expand("Unknown"),
+    cov_cat_hba1c = case_when(is.na(cov_cat_hba1c) ~ factor("Unknown", 
+                                                            levels = c("below 42", "42-58", "59-75", "above 75", "Unknown")), TRUE ~ cov_cat_hba1c)
+  ) %>% 
+  mutate(
+    cov_num_bmi = if_else(
+      cov_num_bmi < 12.00 | cov_num_bmi > 70.00,
+      NA_real_,
+      cov_num_bmi), # also overwrites the baseline value
+    cov_cat_bmi = cut(
+      cov_num_bmi,
+      breaks = c(12, 30, 70),
+      labels = c("Not obese", "Obese"),
+      right = FALSE) %>% 
+      forcats::fct_expand("Unknown"),
+    cov_cat_bmi = case_when(is.na(cov_cat_bmi) ~ factor("Unknown", 
+                                                        levels = c("Not obese", "Obese", "Unknown")), TRUE ~ cov_cat_bmi)
+  )
+
+# To double-check
+# df_months %>%
+#   dplyr::select(patient_id, elig_date_t2dm, landmark_date, month, start_date_month, end_date_month,
+#                 cov_date_chol, cov_num_chol, cov_date_hdl_chol, cov_num_hdl_chol, cov_num_chol_b, cov_num_hdl_chol_b,
+#                 cov_num_tc_hdl_ratio_b, cov_cat_tc_hdl_ratio_b,
+#                 cov_num_tc_hdl_ratio, cov_cat_tc_hdl_ratio,
+#                 cov_date_hba1c, cov_num_hba1c, 
+#                 cov_cat_hba1c,
+#                 cov_num_hba1c_b, cov_cat_hba1c_b,
+#                 cov_date_bmi, cov_num_bmi, 
+#                 cov_num_bmi_b, cov_cat_bmi_groups, cov_bin_obesity, 
+#                 cov_cat_bmi,
+#                 cov_bin_ami, cov_bin_hypertension, cov_bin_all_stroke,
+#                 out_date_severecovid_afterlandmark, out_date_death_afterlandmark,
+#                 cens_date_ltfu_afterlandmark,
+#                 cov_cat_sex, cov_num_age
+#   ) %>%
+#   # filter(is.na(cov_cat_tc_hdl_ratio)) %>%
+#   View()
+
+# drop the baseline values that are not needed anymore
+df_months <- df_months %>%
+  select(!c(cov_num_hdl_chol_b,cov_num_chol_b,
+            cov_num_tc_hdl_ratio_b, cov_cat_tc_hdl_ratio_b,
+            cov_num_hba1c_b, cov_cat_hba1c_b,
+            cov_num_bmi_b, cov_cat_bmi_groups, cov_bin_obesity))
+
+
+# 9. Assign and shift outcome, censoring due to LTFU and competing events --------
+print('Assign and shift outcome, censoring due to LTFU, and competing events')
+# CAVE: use it only after the dataset has been interval-expanded (fn_expand_intervals.R) and after all events have been added (fn_assign* functions)
+
+# Define columns called "outcome", censor_LTFU", "comp_event"
+# Shift them as follows:
+
+## a) outcome is happening in CURRENT (k + 1) interval:
+### i) assign to CURRENT (k + 1) row/person-interval: outcome=NA, censor_LTFU=NA, comp_event=NA
+### ii) assign to the PREVIOUS (k) row/person-interval: outcome=1, censor_LTFU=0, comp_event=0
+
+## b) censor_LTFU is happening in CURRENT (k + 1) interval:
+### i) assign to CURRENT (k + 1) row/person-interval: outcome=NA, censor_LTFU=NA, comp_event=NA
+### ii) assign to the PREVIOUS (k) row/person-interval: outcome=NA, censor_LTFU=1, comp_event=NA # I still think it is possible to replace all NA with 0 without making any difference, since the outcome model is restricted to only rows with df_months[df_months$censor==0 & df_months$comp_event == 0,], but need to check. This is how Miguel's data set is set up, maybe it will have a reason later on, e.g. when looking at competing events. TBD
+
+## c) comp_event is happening in CURRENT (k + 1) interval:
+### i) assign to CURRENT (k + 1) row/person-interval: outcome=NA, censor_LTFU=NA, comp_event=NA
+### ii) assign to the PREVIOUS (k) row/person-interval : outcome=NA, censor_LTFU=0, comp_event=1 # same comment re NA as above
+
+## Edge case RULES
+### d) if outcome and censor_LTFU have the EXACT same date, then pick the outcome as the defining event. Ensured by case_when() order in function.
+### e) if outcome and competing event (i.e. non-covid death) event have the EXACT same date, then pick the outcome as the defining event. Ensured by case_when() order in function.
+### f) if censoring and competing event event have the EXACT same date, then pick the competing event as the defining event. Ensured by case_when() order in function.
+
+## Then, delete all rows/person-intervals with NAs in all three variables (outcome & censor_LTFU & comp_event), i.e., the person-interval the event happened (and by doing this, this also drops the covariate/eligibility/treatment info from that interval)
+## This is the reason, why it needs a dataset per outcome, because the datasets will have different lengths. Alternatively tell the model to ignore info happening after outcome of interest (even if there is data afterwards), but I think this is cleaner, easier and safer.
+
+# Currently, only calendar month and calendar week are implemented
+
+# Primary outcome dataset: stops either at severe covid (includes death and hosp), non-covid death, or deregistration
+df_months_severecovid <- fn_add_and_shift_out_comp_cens_events(df_months,
+                                                               outcome_date_variable = "out_date_severecovid_afterlandmark",
+                                                               comp_date_variable = "out_date_noncoviddeath_afterlandmark",
+                                                               censor_date_variable = "cens_date_ltfu_afterlandmark",
+                                                               studyend_date,
+                                                               interval_type = "month")
+
+# Secondary outcome dataset: stops either at severe covid (includes covid deaths, hosp, diagnoses, tests), non-covid death, or deregistration
+df_months_covid_event <- fn_add_and_shift_out_comp_cens_events(df_months,
+                                                               outcome_date_variable = "out_date_covid",
+                                                               comp_date_variable = "out_date_noncoviddeath_afterlandmark",
+                                                               censor_date_variable = "cens_date_ltfu_afterlandmark",
+                                                               studyend_date,
+                                                               interval_type = "month")
+
+# Secondary outcome dataset: stops either at Long covid diagnosis (includes viral fatigue), any death, or deregistration
+df_months_longcovid <- fn_add_and_shift_out_comp_cens_events(df_months,
+                                                             outcome_date_variable = "out_date_longcovid_virfat",
+                                                             comp_date_variable = "out_date_death_afterlandmark", # all-cause mortality as competing event for this analysis
+                                                             censor_date_variable = "cens_date_ltfu_afterlandmark",
+                                                             studyend_date,
+                                                             interval_type = "month")
+
+# To double-check
+# df_months_severecovid %>%
+#   dplyr::select(patient_id, elig_date_t2dm, start_date_month, end_date_month, month,
+#                 outcome, comp_event, censor_LTFU, stop_date,
+#                 # event_date, is_event_interval, is_outcome_event, is_comp_event, is_cens_event, row_num, first_event_row,
+#                 exp_bin_treat,
+#                 out_date_severecovid_afterlandmark, out_bin_severecovid_afterlandmark,
+#                 out_date_noncoviddeath_afterlandmark, out_bin_noncoviddeath_afterlandmark,
+#                 cens_date_ltfu_afterlandmark, cens_bin_ltfu_afterlandmark,
+#                 out_date_death_afterlandmark, out_bin_death_afterlandmark,
+#                 out_date_covid_afterlandmark, out_bin_covid_afterlandmark,
+#                 cens_date_metfin_start_cont, cens_bin_metfin_start_cont,
+#                 out_date_longcovid_virfat_afterlandmark, out_bin_longcovid_virfat_afterlandmark,
+#                 cov_num_tc_hdl_ratio, cov_cat_tc_hdl_ratio,
+#                 cov_date_chol, cov_num_chol, cov_date_hdl_chol, cov_num_hdl_chol, 
+#                 cov_num_cholesterol_b, cov_num_hdl_cholesterol_b, 
+#                 cov_date_hba1c, cov_num_hba1c, cov_num_hba1c_mmol_mol, cov_cat_hba1c_mmol_mol, 
+#                 cov_date_bmi, cov_num_bmi, cov_cat_bmi_groups, cov_bin_obesity, cov_num_bmi_b, 
+#                 cov_cat_sex, cov_num_age,
+#                 cov_bin_ami, cov_bin_hypertension, cov_bin_all_stroke
+#                 ) %>%
+#   # dplyr::filter(!is.na(out_date_severecovid_afterlandmark)) %>%
+#   # dplyr::filter(!is.na(out_date_noncoviddeath_afterlandmark)) %>%
+#   # dplyr::filter(!is.na(cens_date_ltfu_afterlandmark)) %>%
+#   # dplyr::filter(!is.na(cens_date_metfin_start_cont)) %>%
+#   # dplyr::filter(is.na(censor_LTFU)) %>% # should be empty
+#   View()
+
+
+# 10. Define eligibility --------
+print('Define eligibility')
+# NA in our case, everyone is eligible in this dataset, single-trial approach not sequential trial
+
+
+# 11. Save output -------------------------------------------------------------
+print('Save output')
+arrow::write_feather(df_months_severecovid, here::here("output", "data", "df_months_severecovid.arrow"))
+arrow::write_feather(df_months_covid_event, here::here("output", "data", "df_months_covid_event.arrow"))
+arrow::write_feather(df_months_longcovid, here::here("output", "data", "df_months_longcovid.arrow"))

--- a/analysis/PPA_03_pooled_log_reg.R
+++ b/analysis/PPA_03_pooled_log_reg.R
@@ -1,0 +1,1022 @@
+####
+## This script does the following:
+# 1. Import processed data
+# 2. Estimate adjusted but marginal risks per group, risk differences, risk ratios using (i) standardization and (ii) inverse probability weighting (IPW), 
+#    with the help of pooled logistic regression, and derive 95% CI via bootstrapping
+# 3. Create marginal parametric cumulative incidence (risk) curves incl. 95% CI (via bootstrapping)
+# 4. Save all output
+####
+
+
+# Import libraries and functions ------------------------------------------
+print('Import libraries and functions')
+library(arrow)
+library(here)
+library(tidyverse)
+library(parglm) # to be computationally more efficient
+library(splines)
+library(lubridate)
+library(boot)
+library(Hmisc) # for Love/SMD plot
+source(here::here("analysis", "functions", "fn_smd_before.R"))
+source(here::here("analysis", "functions", "fn_smd_after.R"))
+
+
+# Create directories for output -------------------------------------------
+print('Create directories for output')
+fs::dir_create(here::here("output", "te", "pooled_log_reg"))
+
+
+# Import the data ---------------------------------------------------------
+print('Import the data')
+df_months_severecovid <- read_feather(here("output", "data", "df_months_severecovid.arrow"))
+# df_months_covid_event <- read_feather(here("output", "data", "df_months_covid_event.arrow"))
+# df_months_longcovid <- read_feather(here("output", "data", "df_months_longcovid.arrow"))
+
+
+# Import dates ------------------------------------------------------------
+print('Import dates')
+source(here::here("analysis", "metadates.R"))
+study_dates <- lapply(study_dates, function(x) as.Date(x))
+studyend_date <- as.Date(study_dates$studyend_date, format = "%Y-%m-%d")
+
+
+# Add splines -------------------------------------------------------------
+print('Add splines')
+# Compute knot locations based on percentiles, according to study protocol
+age_knots <- quantile(df_months_severecovid$cov_num_age, probs = c(0.10, 0.50, 0.90))
+df_months_severecovid <- df_months_severecovid %>%
+  mutate(cov_num_age_spline = ns(cov_num_age, knots = age_knots))
+
+
+# Define covariates ----------------------------------------------------------
+print('Define covariates')
+covariate_names <- names(df_months_severecovid) %>%
+  grep("^(cov_num|cov_cat|cov_bin|strat_)", ., value = TRUE) %>% 
+  # exclude those not needed in the model: 
+  ## cov_cat_bmi covers cov_num_bmi,
+  ## cov_cat_hba1c covers cov_num_hba1c
+  ## cov_cat_tc_hdl_ratio covers cov_num_tc_hdl_ratio & cov_num_chol & cov_num_hdl_chol
+  ## cov_num_age_spline covers cov_cat_age and cov_num_age
+  setdiff(c("cov_num_bmi",
+            "cov_num_hba1c",
+            "cov_num_tc_hdl_ratio", "cov_num_chol", "cov_num_hdl_chol",
+            "cov_cat_age", "cov_num_age"
+            )) 
+print(covariate_names)
+
+# Background -----------------------------------------------------
+### a) Pooled logistic regression
+## Pooled logistic regression models allow for the parametric estimation of risks, and thus risk differences and risk ratios.
+## These models can be specified such that the effect of the treatment can vary over time, without relying on a proportional hazards assumption.
+## We're modeling/simulating expected/predicted (counterfactual) risks over time under the assumption that 
+## individuals could have been followed until max fup time (K-1). Hence everyone has predicted risk data until K-1.
+## The aggregation at the end ensures that the true censoring distribution is respected when computing risks.
+
+### b) Adjustment for baseline confounding
+## Adjustment for baseline confounding, i.e. attempt to emulate randomization, can be accomplished using a variety of methods. 
+## We will use (i) inverse probability weighting (IPW) and then (ii) risk estimation via standardisation (parametric g-formula) to get marginal risks (not conditional, but adjusted for confounders)
+
+## IPW 
+## IPW for treatment is used to create a pseudopopulation (i.e.,a hypothetical population) in which treatment is independent of the measured baseline confounders.
+## Informally, the denominator of the inverse probability weight for each individual is the probability of receiving their observed treatment value, given their confounder history.
+## Unstabilized and stabilized weights can be used, we will focus on stabilized.
+## If we want to incorporate time-varying confounding, e.g. for censoring weights or adherence weights (per protocol analysis), 
+## then we then need time-updated / time-varying weights (and info), but can simply multiply all weights
+## We model the follow-up time in the outcome regression model using linear and quadratic terms and include product terms between the treatment group indicator and follow-up time.
+## Other follow-up time modelling would be possible (cubic, splines), we will stick to linear and quadratic term.
+
+## Standardization
+## standardizing over the empirical distribution of the confounders to obtain marginal effect estimates (weighted average of the conditional outcomes)
+
+## We will run through the first dataset/outcome/PLR (severe covid) step by step. For the other outcomes, we use the function at the end to apply everything at once.
+
+
+# Define interval and number of bootstraps -----------------------
+print('Define interval data set and number of bootstraps')
+## We currently only use the monthly interval data set => max follow-up is: K = 39 months (earliest possible landmark_date [01.01.2019] to study end [01.04.2022])
+## If weeks, then K = 169 weeks
+K <- 39 # Total follow-up in months; if we use 39, we allow for the final 1-day fup (01.04.2022-01.04.2022); should not make much difference
+df_months_severecovid$monthsqr <- df_months_severecovid$month^2 # add months square to model time in PLR
+R <- 4 # Total bootstraps (ideally >500)
+
+
+# IPTW: Fit treatment model and truncate the weights ----------------------
+print('IPTW: Fit treatment model and truncate the weights')
+## The denominator of the IPTW for each individual is the probability of receiving their observed(!) treatment value, given their confounder history.
+## Here, we deal with treatment that is defined at baseline, not time-varying uptake of treatment => one constant baseline treatment weight per individual
+## And, the numerator therefore is simply the proportion of patients who were actually treated.
+
+# Calculate denominator for "probability of receiving their observed(!) treatment value"
+iptw_denom_formula <- as.formula(paste("I(exp_bin_treat == 1) ~ ", paste(covariate_names, collapse = " + ")))
+iptw.denom <- parglm(iptw_denom_formula, 
+                     family = binomial(link = 'logit'),
+                     data = df_months_severecovid[df_months_severecovid$month == 0, ]) 
+# summary(iptw.denom)
+# summary(iptw.denom)$coefficients
+coef_summary <- summary(iptw.denom)$coefficients
+# Check if any estimates are NA
+if (anyNA(coef_summary[, "Estimate"])) {
+  warning("Some iptw.denom coefficient estimates are NA!")
+} else {
+  message("All iptw.denom coefficient estimates are valid (no NAs).")
+}
+
+# Get predictions (but only use baseline rows, stable weights over time!)
+df_months_severecovid <- df_months_severecovid %>%
+  group_by(patient_id) %>%
+  mutate(
+    iptw_denom = predict(
+      iptw.denom,
+      newdata = cur_data()[month == 0, ],
+      type = "response"
+    ) %>% first()  # take the first (baseline) prediction and assign to the remaining months
+  ) %>%
+  ungroup()
+
+# Estimate stabilized weights
+p_treat <- mean(df_months_severecovid$exp_bin_treat[df_months_severecovid$month == 0]) # prop treated, based on baseline month only, should not matter in this case, but safer
+df_months_severecovid <- df_months_severecovid %>%
+  mutate(w_treat_stab = ifelse(exp_bin_treat == 1,
+                               p_treat / iptw_denom,
+                               (1 - p_treat) / (1 - iptw_denom)))
+# truncate the weights
+lower_threshold <- quantile(df_months_severecovid$w_treat_stab, 0.01, na.rm = TRUE)
+upper_threshold <- quantile(df_months_severecovid$w_treat_stab, 0.99, na.rm = TRUE)
+df_months_severecovid$w_treat_stab_trunc <- df_months_severecovid$w_treat_stab
+df_months_severecovid$w_treat_stab_trunc[df_months_severecovid$w_treat_stab_trunc < lower_threshold] <- lower_threshold
+df_months_severecovid$w_treat_stab_trunc[df_months_severecovid$w_treat_stab_trunc > upper_threshold] <- upper_threshold
+
+## Min, 25th percentile, median, mean, SD, 75th percentile, and max:
+summary(df_months_severecovid$w_treat_stab)
+sd(df_months_severecovid$w_treat_stab)
+summary(df_months_severecovid$w_treat_stab_trunc)
+sd(df_months_severecovid$w_treat_stab_trunc)
+
+
+# IPTW: Check the weights and the balance ---------------------------------------
+print('IPTW: Check the weights and the balance')
+
+# Restrict to baseline rows
+df_baseline <- df_months_severecovid %>% filter(month == 0)
+
+# List of variables to compare (include more, not only covariate_names, e.g. also the numeric variables for HbA1c and TC/HDL ratio)
+varlist <- names(df_months_severecovid) %>%
+  grep("^(cov_num|cov_cat|cov_bin|strat_)", ., value = TRUE) %>% 
+  # but exclude those that make no sense: 
+  ## cov_num_age_spline and cov_cat_age, represented by cov_num_age
+  setdiff(c("cov_num_age_spline", "cov_cat_age")) 
+print(varlist)
+
+# Create subsets of data, according to treat_b status, at month 0
+treat_b0 <- df_baseline %>% filter(exp_bin_treat==0)
+treat_b1 <- df_baseline %>% filter(exp_bin_treat==1)
+w_treat_0 <- treat_b0$w_treat_stab_trunc
+w_treat_1 <- treat_b1$w_treat_stab_trunc
+
+### Check standardized mean difference BEFORE weighting
+smd_before <- lapply(varlist, fn_smd_before)
+smd_before_df <- as.data.frame(do.call(rbind, smd_before), stringsAsFactors = FALSE)
+smd_before_df <- transform(smd_before_df,
+                           var = as.character(var),
+                           type = as.character(type),
+                           smd = as.numeric(smd))
+covplot_unweighted_severecovid <- ggplot(smd_before_df, aes(x = smd, y = reorder(var, smd))) +
+  geom_point(color = "steelblue", size = 3) +
+  geom_vline(xintercept = c(-0.1, 0.1), linetype = "dashed", color = "red") +
+  labs(title = "Love Plot: Standardized Mean Differences before weighting",
+       x = "Standardized Mean Difference (SMD)",
+       y = "Covariate") +
+  theme_minimal()
+
+### Check standardized mean difference AFTER weighting
+smd_after <- lapply(varlist, 
+                    fn_smd_after, 
+                    w_treat_0 = w_treat_0, 
+                    w_treat_1 = w_treat_1)
+smd_after_df <- as.data.frame(do.call(rbind, smd_after), stringsAsFactors = FALSE)
+smd_after_df <- transform(smd_after_df,
+                          var = as.character(var),
+                          type = as.character(type),
+                          smd = as.numeric(smd))
+covplot_weighted_severecovid <- ggplot(smd_after_df, aes(x = smd, y = reorder(var, smd))) +
+  geom_point(color = "darkorange", size = 3) +
+  geom_vline(xintercept = c(-0.1, 0.1), linetype = "dashed", color = "red") +
+  labs(title = "Love Plot: Standardized Mean Differences after weighting",
+       x = "Standardized Mean Difference (SMD)",
+       y = "Covariate") +
+  theme_minimal()
+
+
+# IPTW: Fit pooled logistic regression -------------------------------------
+print('IPTW: Fit pooled logistic regression and create plot_cum_risk_iptw')
+# Fit pooled logistic regression, with stabilized weights (currently only IPW for treatment, i.e. baseline confounding => same weights across time)
+# Include the treatment group indicator, the follow-up time (linear and quadratic terms), and product terms between the treatment group indicator and follow-up time
+# Train the model only on individuals who were still at risk of the outcome, i.e. only include individuals who are uncensored and alive
+plr_model_severecovid <- parglm(outcome ~ exp_bin_treat + month + monthsqr + I(exp_bin_treat*month) + I(exp_bin_treat*monthsqr), 
+                                family = binomial(link = 'logit'),
+                                data = df_months_severecovid[df_months_severecovid$censor_LTFU==0 & df_months_severecovid$comp_event == 0,],
+                                weights = df_months_severecovid[df_months_severecovid$censor_LTFU==0 & df_months_severecovid$comp_event == 0,]$w_treat_stab_trunc)
+# summary(plr_model_severecovid)
+coef_summary <- summary(plr_model_severecovid)$coefficients
+# Check if any estimates are NA
+if (anyNA(coef_summary[, "Estimate"])) {
+  warning("Some plr_model_severecovid coefficient estimates are NA!")
+} else {
+  message("All plr_model_severecovid coefficient estimates are valid (no NAs).")
+}
+
+### STANDARDIZATION: Transform estimates to risks at each time point in each group ###
+
+# Create dataset with all time points for each individual under each treatment level
+df_pred <- df_months_severecovid %>% filter(month == 0) %>% dplyr::select(-month) %>% crossing(month = 0:(K-1))
+df_pred$monthsqr <- df_pred$month^2
+
+# Control group (everyone untreated) with predicted discrete-time hazards
+df_pred0 <- df_pred
+df_pred0$exp_bin_treat <- 0
+df_pred0$p.event0 <- predict(plr_model_severecovid, df_pred0, type="response")
+
+# Treatment group (everyone treated) with predicted discrete-time hazards
+df_pred1 <- df_pred
+df_pred1$exp_bin_treat <- 1
+df_pred1$p.event1 <- predict(plr_model_severecovid, df_pred1, type="response")
+
+# Obtain predicted survival probabilities from discrete-time hazards
+df_pred0 <- df_pred0 %>% group_by(patient_id) %>% mutate(surv0 = cumprod(1 - p.event0)) %>% ungroup()
+df_pred1 <- df_pred1 %>% group_by(patient_id) %>% mutate(surv1 = cumprod(1 - p.event1)) %>% ungroup()
+
+# Estimate risks from survival probabilities; compute risk at month K-1
+# Risk = 1 - S(t)
+df_pred0$risk0 <- 1 - df_pred0$surv0
+df_pred1$risk1 <- 1 - df_pred1$surv1
+
+# Get the mean in each treatment group at each month time point
+risk0 <- aggregate(df_pred0[c("exp_bin_treat", "month", "risk0")], by=list(df_pred0$month), FUN=mean)[c("exp_bin_treat", "month", "risk0")]
+risk1 <- aggregate(df_pred1[c("exp_bin_treat", "month", "risk1")], by=list(df_pred1$month), FUN=mean)[c("exp_bin_treat", "month", "risk1")]
+
+# Put all in 1 data frame
+graph.pred <- merge(risk0, risk1, by=c("month"))
+
+# Edit data frame to reflect that risks are estimated at the END of each interval
+graph.pred$time_0 <- graph.pred$month + 1
+zero <- data.frame(cbind(0,0,0,1,0,0))
+zero <- setNames(zero,names(graph.pred))
+graph <- rbind(zero, graph.pred) ## can be used for the cumulative incidence plot, but without 95% CI (for that, see below)
+
+# Add RD and RR
+graph$rd <- graph$risk1-graph$risk0
+graph$rr <- graph$risk1/graph$risk0
+
+# Extract overall risk estimate (end of follow-up K-1), but without 95% CI (for that, see below)
+risk0 <- graph$risk0[which(graph$month==K-1)] 
+risk1 <- graph$risk1[which(graph$month==K-1)]
+rd <- graph$rd[which(graph$month==K-1)]
+rr <- graph$rr[which(graph$month==K-1)]
+
+### Construct marginal parametric cumulative incidence (risk) curves (without CIs) ###
+
+# Create plot (without CIs)
+plot_cum_risk_iptw_severecovid <- ggplot(graph,
+                  aes(x=time_0, y=risk)) + 
+  geom_line(aes(y = risk1, 
+                color = "Metformin"), linewidth = 1.5) +
+  geom_line(aes(y = risk0,
+                color = "No Metformin"), linewidth = 1.5) +
+  xlab("Months") +
+  ylab("Cumulative Incidence (%)") + 
+  theme_minimal()+ # set plot theme elements
+  theme(axis.text = element_text(size=14), legend.position = c(0.2, 0.8),
+        axis.line = element_line(colour = "black"),
+        legend.title = element_blank(),
+        panel.grid.major.x = element_blank(),
+        panel.grid.minor.x = element_blank(),
+        panel.grid.minor.y = element_blank(),
+        panel.grid.major.y = element_blank())+
+  scale_color_manual(values=c("#E7B800","#2E9FDF"),
+                     breaks=c('No Metformin', 'Metformin'))
+
+
+# IPTW & IPCW for PPA: Add censoring event weights for the per-protocol analysis ----------------------------------
+print('IPTW & IPCW for PPA: Add censoring event weights for the per-protocol analysis')
+## We want to use IPW for starting treatment in the control group (PPA): cens_bin_metfin_start_cont | “What would the effect have been if everyone had adhered to their assigned strategy?”
+## An uncensored individual’s IPCW is the inverse of their probability of remaining uncensored given their treatment and covariate history. 
+## In the context of the PPA, each individual who continued adhering to their treatment strategy receives a weight that is proportional to the inverse of the probability of adhering to the treatment strategy, given their specific history.
+## Once an individual is censored, they receive a censoring weight of 0 from that point onward. 
+
+## Fit a pooled logistic regression model for the denominator of IPCW
+## This model should predict the probability of remaining uncensored (not deviating from their treatment strategy) at each timepoint. 
+## Continuous time, here months (modeled using linear and quadratic terms), will serve as the time scale for this model. 
+## We do not include any product terms in the model
+
+# Denominator model: P(uncensored | covariates + time); do not include treatment history since our PPA only applies to the control group!
+ipcw_denom_formula <- as.formula(paste("I(cens_bin_metfin_start_cont == 0) ~ month + monthsqr +", paste(covariate_names, collapse = " + ")))
+ipcw.denom <- parglm(ipcw_denom_formula, 
+                     family = binomial(link = 'logit'),
+                     data = df_months_severecovid) 
+# summary(ipcw.denom)
+# summary(ipcw.denom)$coefficients
+coef_summary <- summary(ipcw.denom)$coefficients
+# Check if any estimates are NA
+if (anyNA(coef_summary[, "Estimate"])) {
+  warning("Some ipcw.denom coefficient estimates are NA!")
+} else {
+  message("All ipcw.denom coefficient estimates are valid (no NAs).")
+}
+
+# Obtain predicted probabilities of being uncensored
+df_months_severecovid$ipcw_denom <- predict(ipcw.denom, df_months_severecovid, type="response")
+
+## For the numerator we now fit a model to include the time-varying aspect of the weights - but without any covariates
+# Numerator model: P(uncensored | time only)
+ipcw_num_formula <- as.formula(paste("I(cens_bin_metfin_start_cont == 0) ~ month + monthsqr"))
+ipcw.num <- parglm(ipcw_num_formula, 
+                   family = binomial(link = 'logit'),
+                   data = df_months_severecovid) 
+
+# Obtain predicted probabilities of being uncensored
+df_months_severecovid$ipcw_num <- predict(ipcw.num, df_months_severecovid, type="response")
+
+### Estimate stabilized inverse probability weights for censoring ###
+# Take cumulative products starting at baseline: cumulative product of num/denom
+df_months_severecovid <- df_months_severecovid %>%
+  group_by(patient_id) %>%
+  mutate(
+    # w_cens_stab = cumprod(ipcw_num)/cumprod(ipcw_denom),
+    w_cens_stab = cumprod(ipcw_num/ipcw_denom),
+    # zero out weights after censoring (cens_bin_metfin_start_cont == 1 means censored)
+    w_cens_stab = ifelse(cummax(cens_bin_metfin_start_cont) == 1, 0, w_cens_stab)
+  ) %>%
+  ungroup()
+
+# Take product of weight for censoring and treatment for each individual (take the untruncated w_treat_stab from above, and only then truncate both combined)
+df_months_severecovid$w_treat_cens_stab <- df_months_severecovid$w_treat_stab * df_months_severecovid$w_cens_stab
+
+### Truncate final stabilized weight at the 1st and 99th percentile ###
+lower_threshold <- quantile(df_months_severecovid$w_treat_cens_stab, 0.01, na.rm = TRUE)
+upper_threshold <- quantile(df_months_severecovid$w_treat_cens_stab, 0.99, na.rm = TRUE)
+df_months_severecovid$w_treat_cens_stab_trunc <- df_months_severecovid$w_treat_cens_stab
+df_months_severecovid$w_treat_cens_stab_trunc[df_months_severecovid$w_treat_cens_stab_trunc < lower_threshold] <- lower_threshold
+df_months_severecovid$w_treat_cens_stab_trunc[df_months_severecovid$w_treat_cens_stab_trunc > upper_threshold] <- upper_threshold
+
+###  Min, 25th percentile, median, mean, SD, 75th percentile, and max: truncated weights ###
+summary(df_months_severecovid$w_treat_cens_stab_trunc)
+sd(df_months_severecovid$w_treat_cens_stab_trunc)
+
+## quite variable weights, investigate a bit more, rare censoring events in some months?
+censoring_rates <- df_months_severecovid %>%
+  group_by(month) %>%
+  summarise(censor_rate = mean(cens_bin_metfin_start_cont, na.rm = TRUE), .groups="drop") %>%
+  mutate(censor_rate_pct = round(censor_rate * 100, 2))
+plot_censoring_ppa <- ggplot(censoring_rates, aes(x = month, y = censor_rate_pct)) +
+  geom_line() +
+  geom_point() +
+  ylab("Censoring for starting metformin per month (%)") +
+  xlab("Month") +
+  theme_minimal()
+censoring_weights <- df_months_severecovid %>%
+  group_by(month) %>%
+  summarise(
+    mean_w = mean(w_cens_stab, na.rm = TRUE),
+    sd_w = sd(w_cens_stab, na.rm = TRUE),
+    max_w = max(w_cens_stab, na.rm = TRUE)
+  )
+print(censoring_weights, n = Inf)
+
+# df_months_severecovid %>%
+#   select(patient_id, month, start_date_month, end_date_month, exp_bin_treat, outcome, cens_bin_metfin_start_cont, censor_LTFU, comp_event, w_treat_cens_stab_trunc, w_treat_stab, w_cens_stab, ipcw_num, ipcw_denom) %>%
+#   filter(month == 38) %>%
+#   # filter(w_treat_cens_stab_trunc > 3000) %>%
+#   View()
+
+
+# IPTW & IPCW for PPA: Fit pooled logistic regression -------------------------
+print('IPTW & IPCW for PPA: Fit pooled logistic regression and create plot_cum_risk_iptw_ipcw_severecovid')
+# Fit pooled logistic regression, with stabilized weights for IPTW and IPCW
+# Include the treatment group indicator, the follow-up time (linear and quadratic terms), and product terms between the treatment group indicator and follow-up time
+# Train the model only on individuals who were still at risk of the outcome, i.e. only include individuals who are uncensored and alive
+plr_model_severecovid <- parglm(outcome ~ exp_bin_treat + month + monthsqr + I(exp_bin_treat*month) + I(exp_bin_treat*monthsqr), 
+                                family = binomial(link = 'logit'),
+                                data = df_months_severecovid[df_months_severecovid$censor_LTFU==0 & df_months_severecovid$comp_event == 0,],
+                                weights = df_months_severecovid[df_months_severecovid$censor_LTFU==0 & df_months_severecovid$comp_event == 0,]$w_treat_cens_stab_trunc)
+# summary(plr_model_severecovid)
+coef_summary <- summary(plr_model_severecovid)$coefficients
+# Check if any estimates are NA
+if (anyNA(coef_summary[, "Estimate"])) {
+  warning("Some plr_model_severecovid with PPA censoring coefficient estimates are NA!")
+} else {
+  message("All plr_model_severecovid with PPA censoring coefficient estimates are valid (no NAs).")
+}
+
+### Transform estimates to risks at each time point in each group ###
+
+# Create dataset with all time points for each individual under each treatment level
+df_pred <- df_months_severecovid %>% filter(month == 0) %>% dplyr::select(-month) %>% crossing(month = 0:(K-1))
+df_pred$monthsqr <- df_pred$month^2
+
+# Control group (everyone untreated) with predicted discrete-time hazards
+df_pred0 <- df_pred
+df_pred0$exp_bin_treat <- 0
+df_pred0$p.event0 <- predict(plr_model_severecovid, df_pred0, type="response")
+
+# Treatment group (everyone treated) with predicted discrete-time hazards
+df_pred1 <- df_pred
+df_pred1$exp_bin_treat <- 1
+df_pred1$p.event1 <- predict(plr_model_severecovid, df_pred1, type="response")
+
+# Obtain predicted survival probabilities from discrete-time hazards
+df_pred0 <- df_pred0 %>% group_by(patient_id) %>% mutate(surv0 = cumprod(1 - p.event0)) %>% ungroup()
+df_pred1 <- df_pred1 %>% group_by(patient_id) %>% mutate(surv1 = cumprod(1 - p.event1)) %>% ungroup()
+
+# Estimate risks from survival probabilities; compute risk at month K-1
+# Risk = 1 - S(t)
+df_pred0$risk0 <- 1 - df_pred0$surv0
+df_pred1$risk1 <- 1 - df_pred1$surv1
+
+# Get the mean in each treatment group at each month time point
+risk0 <- aggregate(df_pred0[c("exp_bin_treat", "month", "risk0")], by=list(df_pred0$month), FUN=mean)[c("exp_bin_treat", "month", "risk0")]
+risk1 <- aggregate(df_pred1[c("exp_bin_treat", "month", "risk1")], by=list(df_pred1$month), FUN=mean)[c("exp_bin_treat", "month", "risk1")]
+
+# Put all in 1 data frame
+graph.pred <- merge(risk0, risk1, by=c("month"))
+
+# Edit data frame to reflect that risks are estimated at the END of each interval
+graph.pred$time_0 <- graph.pred$month + 1
+zero <- data.frame(cbind(0,0,0,1,0,0))
+zero <- setNames(zero,names(graph.pred))
+graph <- rbind(zero, graph.pred) ## can be used for the cumulative incidence plot, but without 95% CI (for that, see below)
+
+# Add RD and RR
+graph$rd <- graph$risk1-graph$risk0
+graph$rr <- graph$risk1/graph$risk0
+
+# Extract overall risk estimate (end of follow-up K-1), but without 95% CI (for that, see below)
+risk0 <- graph$risk0[which(graph$month==K-1)] 
+risk1 <- graph$risk1[which(graph$month==K-1)]
+rd <- graph$rd[which(graph$month==K-1)]
+rr <- graph$rr[which(graph$month==K-1)]
+
+### Construct marginal parametric cumulative incidence (risk) curves (without CIs) ###
+
+# Create plot (without CIs)
+plot_cum_risk_iptw_ipcw_severecovid <- ggplot(graph,
+                                              aes(x=time_0, y=risk)) + 
+  geom_line(aes(y = risk1, 
+                color = "Metformin"), linewidth = 1.5) +
+  geom_line(aes(y = risk0,
+                color = "No Metformin"), linewidth = 1.5) +
+  xlab("Months") +
+  ylab("Cumulative Incidence (%)") + 
+  theme_minimal()+ # set plot theme elements
+  theme(axis.text = element_text(size=14), legend.position = c(0.2, 0.8),
+        axis.line = element_line(colour = "black"),
+        legend.title = element_blank(),
+        panel.grid.major.x = element_blank(),
+        panel.grid.minor.x = element_blank(),
+        panel.grid.minor.y = element_blank(),
+        panel.grid.major.y = element_blank())+
+  scale_color_manual(values=c("#E7B800","#2E9FDF"),
+                     breaks=c('No Metformin', 'Metformin'))
+
+
+# IPTW & IPCW for PPA & IPCW for LTFU: Add censoring event weights for LTFU ----------
+print('IPTW & IPCW for PPA & IPCW for LTFU')
+
+## We want to use IPW for two censoring events: a) LTFU, i.e. "the effect had no one been lost to follow-up", and b) starting treatment in the control group (PPA)
+## Informally, an uncensored individual’s inverse probability of censoring weight is the inverse of their probability of remaining uncensored given their treatment and covariate history. 
+## In the context of loss to follow-up, each individual who was not lost to follow-up receives a weight that is proportional to the inverse of the probability of not being lost to follow-up, given their specific history.
+## We will consider stabilized IP weights for censoring, in which the numerator of the weights is the probability of remaining uncensored given an individual’s history
+## Once an individual is censored, they receive a censoring weight of 0 from that point onward. 
+
+## In this simplified example, we assume censoring due to loss to follow-up depends only on the baseline treatment and baseline covariates. 
+## In a second step, we will incorporate time-updated covariate info, too.
+
+## Fit a pooled logistic regression model for the denominator of the IP weights for censoring 
+## This model should predict the probability of remaining uncensored (not being lost to follow-up or not having started treatment) at each timepoint. 
+## Continuous time, here months (modeled using linear and quadratic terms), will serve as the time scale for this model. 
+## We do not include any product terms in the model.
+## Include exp_bin_treat here (different to PPA!)
+
+ipcw_ltfu_denom_formula <- as.formula(paste("I(censor_LTFU == 0) ~ exp_bin_treat + month + monthsqr +", paste(covariate_names, collapse = " + ")))
+ipcw_ltfu.denom <- parglm(ipcw_ltfu_denom_formula, 
+                  family = binomial(link = 'logit'),
+                  data = df_months_severecovid) 
+coef_summary <- summary(ipcw_ltfu.denom)$coefficients
+# Check if any estimates are NA
+if (anyNA(coef_summary[, "Estimate"])) {
+  warning("Some ipcw_ltfu.denom coefficient estimates are NA!")
+} else {
+  message("All ipcw_ltfu.denom coefficient estimates are valid (no NAs).")
+}
+
+# Obtain predicted probabilities of being uncensored for denominator
+df_months_severecovid$ipcw_ltfu_denom <- predict(ipcw_ltfu.denom, df_months_severecovid, type="response")
+
+## For the numerator we now fit a model to include the time-varying aspect of the weights - but without any covariates
+ipcw_ltfu_num_formula <- as.formula(paste("I(censor_LTFU == 0) ~ month + monthsqr"))
+ipcw_ltfu.num <- parglm(ipcw_ltfu_num_formula, 
+                   family = binomial(link = 'logit'),
+                   data = df_months_severecovid) 
+coef_summary <- summary(ipcw_ltfu.num)$coefficients
+# Check if any estimates are NA
+if (anyNA(coef_summary[, "Estimate"])) {
+  warning("Some ipcw_ltfu.num coefficient estimates are NA!")
+} else {
+  message("All ipcw_ltfu.num coefficient estimates are valid (no NAs).")
+}
+
+# Obtain predicted probabilities of being uncensored for numerator
+df_months_severecovid$ipcw_ltfu_num <- predict(ipcw_ltfu.num, df_months_severecovid, type="response")
+
+### Estimate stabilized inverse probability weights for censoring ###
+# Take cumulative products starting at baseline
+df_months_severecovid <- df_months_severecovid %>%
+  group_by(patient_id) %>%
+  mutate(
+    w_cens_ltfu_stab = cumprod(ipcw_ltfu_num/ipcw_ltfu_denom),
+    # zero out weights after censoring (cens_bin_metfin_start_cont == 1 means censored)
+    w_cens_ltfu_stab = ifelse(cummax(censor_LTFU) == 1, 0, w_cens_ltfu_stab)
+  ) %>% 
+  ungroup()
+
+# Take product of weight for censoring and treatment for each individual (take the untruncated w_treat_stab from above)
+df_months_severecovid$w_treat_cens_ltfu_stab <- df_months_severecovid$w_treat_stab * df_months_severecovid$w_cens_stab * df_months_severecovid$w_cens_ltfu_stab
+
+### Truncate final stabilized weight at the 1st and 99th percentile ###
+lower_threshold <- quantile(df_months_severecovid$w_treat_cens_ltfu_stab, 0.01, na.rm = TRUE)
+upper_threshold <- quantile(df_months_severecovid$w_treat_cens_ltfu_stab, 0.99, na.rm = TRUE)
+df_months_severecovid$w_treat_cens_ltfu_stab_trunc <- df_months_severecovid$w_treat_cens_ltfu_stab
+df_months_severecovid$w_treat_cens_ltfu_stab_trunc[df_months_severecovid$w_treat_cens_ltfu_stab_trunc < lower_threshold] <- lower_threshold
+df_months_severecovid$w_treat_cens_ltfu_stab_trunc[df_months_severecovid$w_treat_cens_ltfu_stab_trunc > upper_threshold] <- upper_threshold
+
+###  Min, 25th percentile, median, mean, SD, 75th percentile, and max: truncated weights ###
+summary(df_months_severecovid$w_treat_cens_ltfu_stab_trunc)
+sd(df_months_severecovid$w_treat_cens_ltfu_stab_trunc)
+
+# df_months_severecovid %>%
+#   select(patient_id, outcome, exp_bin_treat, censor_LTFU, cens_bin_metfin_start_cont, month, w_treat_cens_ltfu_stab_trunc, w_cens_ltfu_stab, ipcw_ltfu_num, ipcw_ltfu_denom, w_treat_cens_stab_trunc, w_treat_stab, w_cens_stab, ipcw_num, ipcw_denom) %>%
+#   # filter(cens_bin_metfin_start_cont == 1) %>%
+#   # filter(w_treat_cens_stab_trunc > 3000) %>%
+#   View()
+
+censoring_rates <- df_months_severecovid %>%
+  group_by(month) %>%
+  summarise(censor_rate = mean(censor_LTFU, na.rm = TRUE), .groups="drop") %>%
+  mutate(censor_rate_pct = round(censor_rate * 100, 2))
+plot_censoring_ltfu <- ggplot(censoring_rates, aes(x = month, y = censor_rate_pct)) +
+  geom_line() +
+  geom_point() +
+  ylab("Censoring for LTFU per month (%)") +
+  xlab("Month") +
+  theme_minimal()
+censoring_weights <- df_months_severecovid %>%
+  group_by(month) %>%
+  summarise(
+    mean_w = mean(w_cens_ltfu_stab, na.rm = TRUE),
+    sd_w = sd(w_cens_ltfu_stab, na.rm = TRUE),
+    max_w = max(w_cens_ltfu_stab, na.rm = TRUE)
+  )
+print(censoring_weights, n = Inf)
+
+
+# IPTW & IPCW for PPA & IPCW for LTFU: Fit pooled logistic regression -------------------------
+print('IPTW & IPCW for PPA & IPCW for LTFU: Fit pooled logistic regression and create plot_cum_risk_iptw_ipcw_ltfu_severecovid')
+# Fit pooled logistic regression, with stabilized weights for IPTW and IPCW (both for PPA and LTFU)
+# Include the treatment group indicator, the follow-up time (linear and quadratic terms), and product terms between the treatment group indicator and follow-up time
+# Train the model only on individuals who were still at risk of the outcome, i.e. only include individuals who are uncensored and alive
+plr_model_severecovid <- parglm(outcome ~ exp_bin_treat + month + monthsqr + I(exp_bin_treat*month) + I(exp_bin_treat*monthsqr), 
+                                family = binomial(link = 'logit'),
+                                data = df_months_severecovid[df_months_severecovid$censor_LTFU==0 & df_months_severecovid$comp_event == 0,],
+                                weights = df_months_severecovid[df_months_severecovid$censor_LTFU==0 & df_months_severecovid$comp_event == 0,]$w_treat_cens_ltfu_stab_trunc)
+# summary(plr_model_severecovid)
+coef_summary <- summary(plr_model_severecovid)$coefficients
+# Check if any estimates are NA
+if (anyNA(coef_summary[, "Estimate"])) {
+  warning("Some plr_model_severecovid incl. PPA and LTFU censoring coefficient estimates are NA!")
+} else {
+  message("All plr_model_severecovid incl. PPA and LTFU censoring coefficient estimates are valid (no NAs).")
+}
+
+### Transform estimates to risks at each time point in each group ###
+
+# Create dataset with all time points for each individual under each treatment level
+df_pred <- df_months_severecovid %>% filter(month == 0) %>% dplyr::select(-month) %>% crossing(month = 0:(K-1))
+df_pred$monthsqr <- df_pred$month^2
+
+# Control group (everyone untreated) with predicted discrete-time hazards
+df_pred0 <- df_pred
+df_pred0$exp_bin_treat <- 0
+df_pred0$p.event0 <- predict(plr_model_severecovid, df_pred0, type="response")
+
+# Treatment group (everyone treated) with predicted discrete-time hazards
+df_pred1 <- df_pred
+df_pred1$exp_bin_treat <- 1
+df_pred1$p.event1 <- predict(plr_model_severecovid, df_pred1, type="response")
+
+# Obtain predicted survival probabilities from discrete-time hazards
+df_pred0 <- df_pred0 %>% group_by(patient_id) %>% mutate(surv0 = cumprod(1 - p.event0)) %>% ungroup()
+df_pred1 <- df_pred1 %>% group_by(patient_id) %>% mutate(surv1 = cumprod(1 - p.event1)) %>% ungroup()
+
+# Estimate risks from survival probabilities; compute risk at month K-1
+# Risk = 1 - S(t)
+df_pred0$risk0 <- 1 - df_pred0$surv0
+df_pred1$risk1 <- 1 - df_pred1$surv1
+
+# Get the mean in each treatment group at each month time point
+risk0 <- aggregate(df_pred0[c("exp_bin_treat", "month", "risk0")], by=list(df_pred0$month), FUN=mean)[c("exp_bin_treat", "month", "risk0")]
+risk1 <- aggregate(df_pred1[c("exp_bin_treat", "month", "risk1")], by=list(df_pred1$month), FUN=mean)[c("exp_bin_treat", "month", "risk1")]
+
+# Put all in 1 data frame
+graph.pred <- merge(risk0, risk1, by=c("month"))
+
+# Edit data frame to reflect that risks are estimated at the END of each interval
+graph.pred$time_0 <- graph.pred$month + 1
+zero <- data.frame(cbind(0,0,0,1,0,0))
+zero <- setNames(zero,names(graph.pred))
+graph <- rbind(zero, graph.pred) ## can be used for the cumulative incidence plot, but without 95% CI (for that, see below)
+
+# Add RD and RR
+graph$rd <- graph$risk1-graph$risk0
+graph$rr <- graph$risk1/graph$risk0
+
+# Extract overall risk estimate (end of follow-up K-1), but without 95% CI (for that, see below)
+risk0 <- graph$risk0[which(graph$month==K-1)] 
+risk1 <- graph$risk1[which(graph$month==K-1)]
+rd <- graph$rd[which(graph$month==K-1)]
+rr <- graph$rr[which(graph$month==K-1)]
+
+### Construct marginal parametric cumulative incidence (risk) curves (without CIs) ###
+
+# Create plot (without CIs)
+plot_cum_risk_iptw_ipcw_ltfu_severecovid <- ggplot(graph,
+                            aes(x=time_0, y=risk)) + 
+  geom_line(aes(y = risk1, 
+                color = "Metformin"), linewidth = 1.5) +
+  geom_line(aes(y = risk0,
+                color = "No Metformin"), linewidth = 1.5) +
+  xlab("Months") +
+  ylab("Cumulative Incidence (%)") + 
+  theme_minimal()+ # set plot theme elements
+  theme(axis.text = element_text(size=14), legend.position = c(0.2, 0.8),
+        axis.line = element_line(colour = "black"),
+        legend.title = element_blank(),
+        panel.grid.major.x = element_blank(),
+        panel.grid.minor.x = element_blank(),
+        panel.grid.minor.y = element_blank(),
+        panel.grid.major.y = element_blank())+
+  scale_color_manual(values=c("#E7B800","#2E9FDF"),
+                     breaks=c('No Metformin', 'Metformin'))
+
+
+# IPTW & IPCW for PPA & IPCW for LTFU: Do all steps together incl. 95% CI using bootstrapping -------------------------
+print('IPTW & IPCW for PPA & IPCW for LTFU: Do all steps together incl. 95% CI using bootstrapping and create plot_cum_risk_iptw_ipcw_ltfu_severecovid')
+
+te_iptw_ipcw_rd_rr_withCI <- function(data, indices, data_full, covariate_names) {
+
+  # capture and count unsuccessful bootstraps
+  tryCatch({
+
+  # Resample patient IDs (with replacement)
+  boot.ids <- data[indices, , drop = FALSE] %>%
+    mutate(bootstrap_draw = row_number())  # Assign a unique row for each draw
+
+  # Join back the full time records **for each draw** (i.e. same patient is allowed to be sampled several times, i.e. with replacement)
+  d <- boot.ids %>%
+    left_join(data_full, by = "patient_id", relationship = "many-to-many") %>%
+    mutate(boot_patient_id = paste0(patient_id, "_", bootstrap_draw))
+
+  ### (1) Calculate IPTW
+  iptw_denom_formula <- as.formula(paste("I(exp_bin_treat == 1) ~ ", paste(covariate_names, collapse = " + ")))
+  iptw.denom <- parglm(iptw_denom_formula,
+                       family = binomial(link = 'logit'),
+                       data = d[d$month == 0, ]) # restrict to baseline person-month for model fitting
+  coef_summary <- summary(iptw.denom)$coefficients
+  if (anyNA(coef_summary[, "Estimate"])) {
+    warning("Some iptw.denom coefficient estimates are NA!")
+  }
+  
+  # baseline predictions, one row per patient, based on baseline month covariates only!
+  d <- d %>%
+    group_by(boot_patient_id) %>%
+    mutate(
+      iptw_denom = predict(
+        iptw.denom,
+        newdata = cur_data()[month == 0, ],
+        type = "response"
+      ) %>% first()  # take the first (baseline) prediction and assign to the remaining months
+    ) %>%
+    ungroup()
+  
+  # d$iptw_denom <- predict(iptw.denom, d, type="response") # works but wrong if time-varying covariates
+
+  # check that no NA in predictions that will mess up calculations later down the road
+  if (any(is.na(d$iptw_denom) | is.infinite(d$iptw_denom))) {
+    stop("iptw_denom has invalid stabilized weights (NA or Inf)")
+  }
+
+  # Estimate stabilized weights
+  p_treat <- mean(d$exp_bin_treat[d$month == 0]) # prop treated, based on baseline month only, should not matter in this case, but safer
+  d <- d %>%
+    mutate(w_treat_stab = ifelse(exp_bin_treat == 1,
+                                 p_treat / iptw_denom,
+                                 (1 - p_treat) / (1 - iptw_denom)))
+
+  if (any(is.na(d$w_treat_stab) | is.infinite(d$w_treat_stab))) {
+    stop("w_treat_stab has invalid stabilized weights (NA or Inf)")
+  }
+  
+
+  ### (2) Calculate IPCW for PPA
+  ipcw_denom_formula <- as.formula(paste("I(cens_bin_metfin_start_cont == 0) ~ month + monthsqr +", paste(covariate_names, collapse = " + ")))
+  ipcw.denom <- parglm(ipcw_denom_formula,
+                       family = binomial(link = 'logit'),
+                       data = d)
+  coef_summary <- summary(ipcw.denom)$coefficients
+  if (anyNA(coef_summary[, "Estimate"])) {
+    warning("Some ipcw.denom coefficient estimates are NA!")
+  }
+
+  # Obtain predicted probabilities of being uncensored for denominator
+  d$ipcw_denom <- predict(ipcw.denom, d, type="response")
+  if (any(is.na(d$ipcw_denom))) {
+    stop("NA in IPCW for PPA denominator predictions")
+  }
+  if(any(d$ipcw_denom <= 0 | d$ipcw_denom >= 1, na.rm=TRUE)) {
+    cat("Problematic ipcw_denom values:", sum(d$ipcw_denom <= 0 | d$ipcw_denom >= 1, na.rm=TRUE), "\n")
+  }
+
+  ## For the numerator we now fit a model to include the time-varying aspect of the weights
+  ipcw_num_formula <- as.formula(paste("I(cens_bin_metfin_start_cont == 0) ~ month + monthsqr"))
+  ipcw.num <- parglm(ipcw_num_formula,
+                  family = binomial(link = 'logit'),
+                  data = d)
+
+  # Obtain predicted probabilities of being uncensored for numerator
+  d$ipcw_num <- predict(ipcw.num, d, type="response")
+
+  if (any(is.na(d$ipcw_num))) {
+    stop("NA in IPCW for PPA numerator predictions")
+  }
+
+  # Take the cumulative product
+  d <- d %>%
+    group_by(boot_patient_id) %>%
+    mutate(
+      w_cens_stab = cumprod(ipcw_num/ipcw_denom),
+      w_cens_stab = ifelse(cummax(cens_bin_metfin_start_cont) == 1, 0, w_cens_stab)
+    ) %>%
+    ungroup()
+  
+  
+  ### (3) Calculate IPCW for LTFU
+  ipcw_ltfu_denom_formula <- as.formula(paste("I(censor_LTFU == 0) ~ exp_bin_treat + month + monthsqr +", paste(covariate_names, collapse = " + ")))
+  ipcw_ltfu.denom <- parglm(ipcw_ltfu_denom_formula,
+                       family = binomial(link = 'logit'),
+                       data = d)
+  coef_summary <- summary(ipcw_ltfu.denom)$coefficients
+  if (anyNA(coef_summary[, "Estimate"])) {
+    warning("Some ipcw_ltfu.denom coefficient estimates are NA!")
+  }
+  
+  # Obtain predicted probabilities of being uncensored for denominator
+  d$ipcw_ltfu_denom <- predict(ipcw_ltfu.denom, d, type="response")
+  if (any(is.na(d$ipcw_ltfu_denom))) {
+    stop("NA in IPCW for LTFU denominator predictions")
+  }
+  if(any(d$ipcw_ltfu_denom <= 0 | d$ipcw_ltfu_denom >= 1, na.rm=TRUE)) {
+    cat("Problematic ipcw_ltfu_denom values:", sum(d$ipcw_ltfu_denom <= 0 | d$ipcw_ltfu_denom >= 1, na.rm=TRUE), "\n")
+  }
+  
+  ## For the numerator we now fit a model to include the time-varying aspect of the weights
+  ipcw_ltfu_num_formula <- as.formula(paste("I(censor_LTFU == 0) ~ month + monthsqr"))
+  ipcw_ltfu.num <- parglm(ipcw_ltfu_num_formula,
+                     family = binomial(link = 'logit'),
+                     data = d)
+  coef_summary <- summary(ipcw_ltfu.denom)$coefficients
+  if (anyNA(coef_summary[, "Estimate"])) {
+    warning("Some ipcw_ltfu.num coefficient estimates are NA!")
+  }
+  
+  # Obtain predicted probabilities of being uncensored for numerator
+  d$ipcw_ltfu_num <- predict(ipcw_ltfu.num, d, type="response")
+  if (any(is.na(d$ipcw_ltfu_num))) {
+    stop("NA in IPCW for PPA numerator predictions")
+  }
+  
+  # Take the cumulative product
+  d <- d %>%
+    group_by(boot_patient_id) %>%
+    mutate(
+      w_cens_ltfu_stab = cumprod(ipcw_ltfu_num/ipcw_ltfu_denom),
+      w_cens_ltfu_stab = ifelse(cummax(censor_LTFU) == 1, 0, w_cens_ltfu_stab)
+    ) %>% 
+    ungroup()
+  
+
+  ### (4) Multiply IPTW * IPCW for PPA * IPCW for LTFU
+  d$w_treat_cens_stab <- d$w_treat_stab * d$w_cens_ltfu_stab * d$w_cens_stab 
+  
+  if (any(is.na(d$w_treat_cens_stab))) {
+    cat("NA in final weight w_treat_cens_stab:", sum(is.na(d$w_treat_cens_stab)), "\n")
+  }
+
+  
+  ### (5) Truncate final stabilized weight at the 1st and 99th percentile
+  lower_threshold <- quantile(d$w_treat_cens_stab, 0.01)
+  upper_threshold <- quantile(d$w_treat_cens_stab, 0.99)
+  d$w_treat_cens_stab_trunc <- d$w_treat_cens_stab
+  d$w_treat_cens_stab_trunc[d$w_treat_cens_stab_trunc < lower_threshold] <- lower_threshold
+  d$w_treat_cens_stab_trunc[d$w_treat_cens_stab_trunc > upper_threshold] <- upper_threshold
+
+  ### (6) Fit pooled logistic regression, with stabilized weights for IPTW and IPCW
+  # Include the treatment group indicator, the follow-up time (linear and quadratic terms), and product terms between the treatment group indicator and follow-up time
+  # Train the model only on individuals who were still at risk of the outcome, i.e. only include individuals who are uncensored and alive
+  # If "I(exp_bin_treat*month) + I(exp_bin_treat*monthsqr)" is excluded, then it would mirror the cox model
+  plr_model_severecovid <- parglm(outcome ~ exp_bin_treat + month + monthsqr + I(exp_bin_treat*month) + I(exp_bin_treat*monthsqr),
+                                  family = binomial(link = 'logit'),
+                                  data = d[d$censor_LTFU==0 & d$comp_event == 0,],
+                                  weights = d[d$censor_LTFU==0 & d$comp_event == 0,]$w_treat_cens_stab_trunc)
+  coef_summary <- summary(plr_model_severecovid)$coefficients
+  if (anyNA(coef_summary[, "Estimate"])) {
+    warning("Some plr_model_severecovid coefficient estimates are NA!")
+  }
+
+  ### (7) Transform estimates to risks at each time point in each group
+  # Create dataset with all time points for each individual under each treatment level
+  treat0 <- d %>% filter(month == 0) %>% dplyr::select(-month) %>% crossing(month = 0:(K-1))
+  treat0$monthsqr <- treat0$month^2
+
+  # In the no metformin arm ("force" everyone to be untreated)
+  treat0$exp_bin_treat <- 0
+  # In the metformin arm ("force" everyone to be treated)
+  treat1 <- treat0
+  treat1$exp_bin_treat <- 1
+
+  # Extract predicted values from pooled logistic regression model for each person-time row
+  # Predicted values correspond to discrete-time hazards
+  treat0$p.event0 <- predict(plr_model_severecovid, treat0, type="response")
+  treat1$p.event1 <- predict(plr_model_severecovid, treat1, type="response")
+  # The above creates a person-time dataset where we have predicted discrete-time hazards
+  # For each person-time row in the dataset
+
+  # Obtain predicted survival probabilities from discrete-time hazards
+  treat0.surv <- treat0 %>% group_by(boot_patient_id) %>% mutate(surv0 = cumprod(1 - p.event0)) %>% ungroup()
+  treat1.surv <- treat1 %>% group_by(boot_patient_id) %>% mutate(surv1 = cumprod(1 - p.event1)) %>% ungroup()
+
+  # Estimate risks from survival probabilities
+  # Risk = 1 - S(t)
+  treat0.surv$risk0 <- 1 - treat0.surv$surv0
+  treat1.surv$risk1 <- 1 - treat1.surv$surv1
+
+  # Get the mean in each treatment group at each month time point
+  risk0 <- aggregate(treat0.surv[c("exp_bin_treat", "month", "risk0")], by=list(treat0.surv$month), FUN=mean)[c("exp_bin_treat", "month", "risk0")]
+  risk1 <- aggregate(treat1.surv[c("exp_bin_treat", "month", "risk1")], by=list(treat1.surv$month), FUN=mean)[c("exp_bin_treat", "month", "risk1")]
+
+  # Prepare data
+  graph.pred <- merge(risk0, risk1, by=c("month"))
+  # Edit data frame to reflect that risks are estimated at the END of each interval
+  graph.pred$time_0 <- graph.pred$month + 1
+  zero <- data.frame(cbind(0,0,0,1,0,0))
+  zero <- setNames(zero,names(graph.pred))
+  graph <- rbind(zero, graph.pred)
+  graph$rd <- graph$risk1-graph$risk0
+  graph$rr <- graph$risk1/graph$risk0
+  return(c(graph$risk0, graph$risk1, graph$rd, graph$rr))
+
+  }, error = function(e) {
+    # If any error occurs, count as a failed bootstrap
+    cat("Bootstrap sample failed due to:", conditionMessage(e), "\n")
+    boot_failures <<- boot_failures + 1
+    return(rep(NA, length(c(graph$risk0, graph$risk1, graph$rd, graph$rr)))) # Return NA values to avoid breaking the boot()
+  })
+
+}
+
+### RUN it, for each outcome/dataset
+set.seed(443)
+boot_failures <- 0 # Reset failure counter
+
+## Severe COVID / primary outcome
+# extract unique identifiers, as a data frame
+study_ids <- data.frame(patient_id = unique(df_months_severecovid$patient_id))
+# add dataset, covariate list (see above), and boostrap runs (see above)
+te_iptw_ipcw_rd_rr_withCI_severecovid_boot <- boot(
+  data = study_ids,
+  statistic = function(data, indices) {
+    te_iptw_ipcw_rd_rr_withCI(data, indices, data_full = df_months_severecovid, covariate_names = covariate_names)
+  },
+  R = R
+)
+cat("Number of failed bootstrap samples:", boot_failures, "\n")
+
+### risk tables
+# Function to extract bootstrapped confidence intervals for a time point - and keep a column with the original point estimates (without CI)
+extract_ci_boot <- function(boot_obj, index) {
+  ci <- boot.ci(boot_obj, conf = 0.95, type = "perc", index = index)
+  if (!is.null(ci$percent)) {
+    return(c(ci$percent[4], ci$percent[5])) # Lower and Upper CI for the bootstrapped values
+  } else {
+    return(c(NA, NA)) # for the original value
+  }
+}
+
+# Identify target months (indices) for when to extract risk estimates.
+# The final time point is index K, since R indexes from 1 (even though we shifted month to K - 1 above to start at month == 0)
+k_39_index <- K   # final time point (K = 39 if months 0 to 38)
+k_24_index <- 25  # corresponds to month 24, because R is 1-indexed => corresponds to Cox 730 days timepoint
+indices_39 <- c(k_39_index, 2*k_39_index, 3*k_39_index, 4*k_39_index)
+indices_24 <- c(k_24_index, 2*k_24_index, 3*k_24_index, 4*k_24_index)
+
+te_plr_iptw_ipcw_severecovid_39_boot_tbl <- data.frame(
+  Measure = c("Risk Control", "Risk Treatment", "Risk Difference", "Risk Ratio"),
+  Estimate_original = te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t0[indices_39],
+  Estimate_boot = colMeans(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, indices_39], na.rm = TRUE),
+  Lower_CI = sapply(indices_39, function(i) extract_ci_boot(te_iptw_ipcw_rd_rr_withCI_severecovid_boot, i)[1]),
+  Upper_CI = sapply(indices_39, function(i) extract_ci_boot(te_iptw_ipcw_rd_rr_withCI_severecovid_boot, i)[2])
+)
+te_plr_iptw_ipcw_severecovid_24_boot_tbl <- data.frame(
+  Measure = c("Risk Control", "Risk Treatment", "Risk Difference", "Risk Ratio"),
+  Estimate_original = te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t0[indices_24],
+  Estimate_boot = colMeans(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, indices_24], na.rm = TRUE),
+  Lower_CI = sapply(indices_24, function(i) extract_ci_boot(te_iptw_ipcw_rd_rr_withCI_severecovid_boot, i)[1]),
+  Upper_CI = sapply(indices_24, function(i) extract_ci_boot(te_iptw_ipcw_rd_rr_withCI_severecovid_boot, i)[2])
+)
+
+
+### risk plots
+# Create an empty data frame to store the structured output for the plot
+risk_graph <- data.frame(
+  time = 0:K,
+  mean.0 = numeric(K+1),
+  ll.0 = numeric(K+1),
+  ul.0 = numeric(K+1),
+  mean.1 = numeric(K+1),
+  ll.1 = numeric(K+1),
+  ul.1 = numeric(K+1)
+)
+
+# Calculate the mean and confidence intervals
+mean_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, mean) # Mean for control group (first half contains risk0)
+mean_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, mean) # Mean for treatment group (second half contains risk1)
+
+ll_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, function(x) quantile(x, 0.025))
+ul_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, function(x) quantile(x, 0.975))
+
+ll_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, function(x) quantile(x, 0.025))
+ul_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, function(x) quantile(x, 0.975))
+
+# Populate the `risk.boot.graph` data frame
+risk_graph$mean.0 <- mean_risk0
+risk_graph$ll.0 <- ll_risk0
+risk_graph$ul.0 <- ul_risk0
+risk_graph$mean.1 <- mean_risk1
+risk_graph$ll.1 <- ll_risk1
+risk_graph$ul.1 <- ul_risk1
+
+# Create plot
+plot_cum_risk_iptw_ipcw_ltfu_ci_severecovid <- ggplot(risk_graph,
+                        aes(x=time)) +
+  geom_line(aes(y = mean.1, # create line for intervention group
+                color = "Metformin"), linewidth = 1.5) +
+  geom_ribbon(aes(ymin = ll.1, ymax = ul.1, fill = "Metformin"), alpha = 0.4) +
+  geom_line(aes(y = mean.0, # create line for control group
+                color = "No Metformin"), linewidth = 1.5) +
+  geom_ribbon(aes(ymin = ll.0, ymax = ul.0, fill = "No Metformin"), alpha=0.4) +
+  xlab("Months") +
+  ylab("Cumulative Incidence (%)") +
+  theme_minimal()+
+  theme(axis.text = element_text(size=14), legend.position = c(0.2, 0.8),
+        axis.line = element_line(colour = "black"),
+        legend.title = element_blank(),
+        panel.grid.major.x = element_blank(),
+        panel.grid.minor.x = element_blank(),
+        panel.grid.minor.y = element_blank(),
+        panel.grid.major.y = element_blank())+
+  scale_color_manual(values=c("#E7B800",
+                              "#2E9FDF"),
+                     breaks=c('No Metformin',
+                              'Metformin')) +
+  scale_fill_manual(values=c("#E7B800",
+                             "#2E9FDF"),
+                    breaks=c('No Metformin',
+                             'Metformin'))
+
+
+# Save output -------------------------------------------------------------
+print('Save output')
+## primary outcome: Severe COVID
+# Love/SMD plot
+ggsave(filename = here::here("output", "te", "pooled_log_reg", "covplot_unweighted_severecovid.png"), covplot_unweighted_severecovid, width = 20, height = 20, units = "cm")
+ggsave(filename = here::here("output", "te", "pooled_log_reg", "covplot_weighted_severecovid.png"), covplot_weighted_severecovid, width = 20, height = 20, units = "cm")
+# Censoring plots
+ggsave(filename = here::here("output", "te", "pooled_log_reg", "plot_censoring_ppa.png"), plot_censoring_ppa, width = 20, height = 20, units = "cm")
+ggsave(filename = here::here("output", "te", "pooled_log_reg", "plot_censoring_ltfu.png"), plot_censoring_ltfu, width = 20, height = 20, units = "cm")
+# Treatment effect (risk) estimates at max follow-up (39 months)
+write.csv(te_plr_iptw_ipcw_severecovid_39_boot_tbl, file = here::here("output", "te", "pooled_log_reg", "te_plr_iptw_ipcw_severecovid_39_boot_tbl.csv"))
+# Treatment effect (risk) estimates at 24 months (corresponding to Cox model)
+write.csv(te_plr_iptw_ipcw_severecovid_24_boot_tbl, file = here::here("output", "te", "pooled_log_reg", "te_plr_iptw_ipcw_severecovid_24_boot_tbl.csv"))
+# Marginal parametric cumulative incidence (risk) curves from plr model, last one including 95% CI
+ggsave(filename = here::here("output", "te", "pooled_log_reg", "plot_cum_risk_iptw_severecovid.png"), plot_cum_risk_iptw_severecovid, width = 20, height = 20, units = "cm")
+ggsave(filename = here::here("output", "te", "pooled_log_reg", "plot_cum_risk_iptw_ipcw_severecovid.png"), plot_cum_risk_iptw_ipcw_severecovid, width = 20, height = 20, units = "cm")
+ggsave(filename = here::here("output", "te", "pooled_log_reg", "plot_cum_risk_iptw_ipcw_ltfu_severecovid.png"), plot_cum_risk_iptw_ipcw_ltfu_severecovid, width = 20, height = 20, units = "cm")
+ggsave(filename = here::here("output", "te", "pooled_log_reg", "plot_cum_risk_iptw_ipcw_ltfu_ci_severecovid.png"), plot_cum_risk_iptw_ipcw_ltfu_ci_severecovid, width = 20, height = 20, units = "cm")

--- a/analysis/PPA_modify_dummy_data_df_months.R
+++ b/analysis/PPA_modify_dummy_data_df_months.R
@@ -1,0 +1,35 @@
+#### 
+## This script modifies dummy data of df_months to: 
+## - randomly select 50% of cov_date_ami 
+## - change them to be very close to the treatment information change, i.e., cens_date_metfin_start_cont (within 5 days before/after cens_date_metfin_start_cont)
+## - this will test edge cases for fn_assign_time_fixed_cov
+####
+
+# Identify eligible persons (both dates non-NA)
+eligible_persons <- df_months %>%
+  distinct(patient_id, cov_date_ami, cens_date_metfin_start_cont) %>%
+  filter(!is.na(cov_date_ami) & !is.na(cens_date_metfin_start_cont)) %>%
+  pull(patient_id)
+
+# Randomly select ~50% of them
+n_change <- ceiling(0.50 * length(eligible_persons))
+persons_to_change <- sample(eligible_persons, n_change)
+
+# Compute new cov_date_ami for selected persons
+new_dates <- df_months %>%
+  distinct(patient_id, cov_date_ami, cens_date_metfin_start_cont) %>%
+  filter(patient_id %in% persons_to_change) %>%
+  mutate(
+    new_cov_date_ami = cens_date_metfin_start_cont + sample(c(-5:-1, 1:5), n(), replace=TRUE)
+  ) %>%
+  select(patient_id, new_cov_date_ami)
+
+# Merge back into original data
+df_months <- df_months %>%
+  left_join(new_dates, by="patient_id") %>%
+  mutate(
+    cov_date_ami = ifelse(patient_id %in% persons_to_change, new_cov_date_ami, cov_date_ami)
+  ) %>%
+  select(-new_cov_date_ami)
+
+df_months$cov_date_ami <- as.Date(df_months$cov_date_ami, origin = "1970-01-01")

--- a/analysis/PPA_modify_dummy_data_df_ppa_long.R
+++ b/analysis/PPA_modify_dummy_data_df_ppa_long.R
@@ -1,0 +1,37 @@
+#### 
+## This script modifies dummy data of df_ppa_long to: 
+## - randomly select 5% of "date" (which is the date variable for all measurements in df_ppa_long)
+## - change them to be very close to cens_date_metfin_start_cont (within 3 days before/after cens_date_metfin_start_cont)
+## - this will test edge cases
+####
+
+# Identify eligible persons (both dates non-NA)
+eligible_persons <- df_ppa_long %>%
+  distinct(patient_id, date, variable, instance, cens_date_metfin_start_cont) %>%
+  filter(!is.na(date) & !is.na(cens_date_metfin_start_cont)) %>%
+  pull(patient_id)
+
+# Randomly select ~5% of them
+n_change <- ceiling(0.05 * length(eligible_persons))
+persons_to_change <- sample(eligible_persons, n_change)
+
+# Compute new date for selected persons
+new_dates <- df_ppa_long %>%
+  distinct(patient_id, date, variable, instance, cens_date_metfin_start_cont) %>%
+  filter(patient_id %in% persons_to_change) %>%
+  mutate(
+    new_date = cens_date_metfin_start_cont + sample(c(-3:-1, 1:3), n(), replace=TRUE)
+  ) %>%
+  select(patient_id, new_date, variable, instance)
+new_dates <- new_dates %>% arrange(patient_id, variable, new_date)
+
+# Merge back into original data
+df_ppa_long <- df_ppa_long %>% arrange(patient_id, variable, date)
+df_ppa_long <- df_ppa_long %>%
+  left_join(new_dates, by=c("patient_id", "variable", "instance")) %>%
+  mutate(
+    date = ifelse(patient_id %in% persons_to_change, new_date, date)
+  ) %>%
+  select(-new_date)
+
+df_ppa_long$date <- as.Date(df_ppa_long$date, origin = "1970-01-01")

--- a/analysis/functions/fn_add_and_shift_out_comp_cens_events.R
+++ b/analysis/functions/fn_add_and_shift_out_comp_cens_events.R
@@ -1,0 +1,101 @@
+####
+# Custom-made function to add outcome, competing and censoring events to an expanded person-interval dataset
+
+# Define columns called "outcome", censor_LTFU", "comp_event"
+# Shift them as follows:
+
+## a) outcome is happening in CURRENT (k + 1) interval:
+### i) assign to CURRENT (k + 1) row/person-interval: outcome=NA, censor_LTFU=NA, comp_event=NA
+### ii) assign to the PREVIOUS (k) row/person-interval: outcome=1, censor_LTFU=0, comp_event=0
+
+## b) censor_LTFU is happening in CURRENT (k + 1) interval:
+### i) assign to CURRENT (k + 1) row/person-interval: outcome=NA, censor_LTFU=NA, comp_event=NA
+### ii) assign to the PREVIOUS (k) row/person-interval: outcome=NA, censor_LTFU=1, comp_event=NA # I still think it is possible to replace all NA with 0 without making any difference, since the outcome model is restricted to only rows with df_months[df_months$censor==0 & df_months$comp_event == 0,], but need to check. This is how Miguel's data set is set up, maybe it will have a reason later on, e.g. when looking at competing events. TBD
+
+## c) comp_event is happening in CURRENT (k + 1) interval:
+### i) assign to CURRENT (k + 1) row/person-interval: outcome=NA, censor_LTFU=NA, comp_event=NA
+### ii) assign to the PREVIOUS (k) row/person-interval : outcome=NA, censor_LTFU=0, comp_event=1 # same comment re NA as above
+
+## Edge case rules
+### d) if outcome and censor_LTFU have the EXACT same date, then pick the outcome as the defining event. Ensured by case_when() order in function.
+### e) if outcome and competing event (i.e. non-covid death) event have the EXACT same date, then pick the outcome as the defining event. Ensured by case_when() order in function.
+### f) if censoring and competing event event have the EXACT same date, then pick the competing event as the defining event. Ensured by case_when() order in function.
+
+## Then, delete all rows/person-intervals with NAs in all three variables (outcome & censor_LTFU & comp_event), i.e., the person-interval the event happened (and by doing this, this also drops the covariate/eligibility/treatment info from that interval)
+## This is the reason, why it needs a dataset per outcome, because the datasets will have different lengths. Alternatively tell the model to ignore info happening after outcome of interest (even if there is data afterwards), but I think this is cleaner, easier and safer.
+
+# Currently, only calendar month and calendar week are implemented
+
+fn_add_and_shift_out_comp_cens_events <- function(data, 
+                                          outcome_date_variable, 
+                                          comp_date_variable, 
+                                          censor_date_variable, 
+                                          studyend_date, 
+                                          interval_type = c("week", "month")) {
+  interval_type <- match.arg(interval_type)
+  
+  data %>%
+    group_by(patient_id) %>%
+    mutate(
+      # Use the dates (not the bin flags), since in some scenarios an outcome and censoring or competing event might occur in same interval. I will only consider what happens first (pmin)
+      event_date = pmin(.data[[outcome_date_variable]], .data[[comp_date_variable]], .data[[censor_date_variable]], studyend_date, na.rm = TRUE),
+
+      is_event_interval = (.data[[paste0("start_date_", interval_type)]] <= event_date) & (event_date <= .data[[paste0("end_date_", interval_type)]]),
+
+      is_outcome_event = if_else(is_event_interval & event_date == .data[[outcome_date_variable]], 1L, 0L),
+      is_comp_event = if_else(is_event_interval & event_date == .data[[comp_date_variable]], 1L, 0L),
+      is_cens_event = if_else(is_event_interval & event_date == .data[[censor_date_variable]], 1L, 0L),
+      
+      outcome = case_when(
+        # define entry for interval prior to event
+        lead(is_outcome_event, default = 0) == 1 ~ 1, # Is the outcome event happening in next interval? If so, assign 1 to current (= prior) interval
+        lead(is_comp_event, default = 0) == 1 ~ NA_real_, # Is the competing event happening in next interval? If so, assign NA to current (= prior) interval
+        lead(is_cens_event, default = 0) == 1 ~ NA_real_, # Is the censoring event happening in next interval? If so, assign NA to current (= prior) interval
+        # define entry for interval when event is happening
+        is_outcome_event == 1 ~ NA_real_, # to current interval assign NA (i.e. to interval where death happens)
+        is_comp_event == 1 ~ NA_real_, # event is the competing event, assign NA to current interval
+        is_cens_event == 1 ~ NA_real_, # event is the censoring event, assign NA to current interval
+        TRUE ~ 0 # Assign 0 to all other intervals - and in case of no event happened (i.e. end of follow-up)
+      ),
+      
+      comp_event = case_when(
+        # define entry for interval prior to event
+        lead(is_outcome_event, default = 0) == 1 ~ 0, 
+        lead(is_comp_event, default = 0) == 1 ~ 1, 
+        lead(is_cens_event, default = 0) == 1 ~ NA_real_,
+        # define entry for interval when event is happening
+        is_comp_event == 1 ~ NA_real_,
+        is_outcome_event == 1 ~ NA_real_,
+        is_cens_event == 1 ~ NA_real_,
+        TRUE ~ 0
+      ),
+      
+      censor_LTFU = case_when(
+        # define entry for interval prior to event
+        lead(is_outcome_event, default = 0) == 1 ~ 0, 
+        lead(is_comp_event, default = 0) == 1 ~ 0,
+        lead(is_cens_event, default = 0) == 1 ~ 1, 
+        # define entry for interval when event is happening
+        is_comp_event == 1 ~ NA_real_,
+        is_outcome_event == 1 ~ NA_real_,
+        is_cens_event == 1 ~ NA_real_,
+        TRUE ~ 0
+      )
+      
+    ) %>%
+    
+    # In scenarios where the outcome is not a final/fatal outcome (e.g. covid hospitalization or long covid) the dataset will have rows after such an event.
+    # Make sure there is no data after an outcome, comp, or censoring event happened
+    mutate(row_num = row_number()) %>%
+    mutate(first_event_row = min(ifelse(is_event_interval, row_num, Inf))) %>% # in case there is no event at all (i.e. end of follow-up is the stopping event)
+    filter(row_num <= first_event_row) %>%
+    
+    ungroup() %>%
+    
+    # Drop rows where outcome, censor and comp_event are all NA -> these are the intervals where outcomes happened, but we shifted the info to the row above => drop these rows
+    filter(!(is.na(outcome) & is.na(censor_LTFU) & is.na(comp_event))) %>%
+    
+    # Drop helper variables
+    select(-event_date, -is_event_interval, -is_outcome_event, -is_comp_event, -is_cens_event, -row_num, -first_event_row)
+  
+}

--- a/analysis/functions/fn_assign_dynamic_tu_cov.R
+++ b/analysis/functions/fn_assign_dynamic_tu_cov.R
@@ -1,0 +1,109 @@
+####
+# Custom-made function to add dynamic time-updated covariates to person-interval data and adhere to specific rules:
+#### 
+# rule (a) If cov_date is in same interval as treatment info change but cov_date > treatment info change, then flag the one closest to end_date_month to be moved ("MOVER") to the next month (and discard other cov_date that are in same interval and with cov_date > treatment info change)
+# rule (b) If cov_date is in same interval as treatment info change but cov_date <= treatment info change, then flag the one on or closest to treatment info change to keep ("KEEPER") in the same month (and discard the others that are also in same interval as treatment info change and cov_date <= treatment info change)
+## (btw, if at the same time, there were also cov_date > treatment info change in same interval, they will have been dealt with in rule (a) already)
+# rule (c) If cov_date is not in same interval as treatment info change, then flag the one closest to end_date_month to be moved ("MOVER") to the next month (and discard all others)
+# Then, shift all "MOVERS" to the next month, and keep all "KEEPERS" in the original month
+
+## Then, deal with edge cases: 
+# (i) We may have months whereby we moved a "MOVER" covariate due to rule (c) or rule (a) into a month with a "KEEPER" covariate (rule b) => more than 1 covariate info in same person-interval
+## => Solution: "KEEPER" beats "MOVER", i.e., the one that was flagged as "KEEPER" (because it contains time-update covariate info JUST before treatment change) is more important and wins
+### (Side-note: In our case, we only have treatment update once, so a move due to rule (a) ending up in a month with a "KEEPER" covariate (rule b) is impossible - but the function/rules work with more complex dynamic treatment updates, too)
+## (ii) We may have the scenario whereby treatment update info and covariate update info change on same date (and no time-stamp to differentiate)
+## => Solution: Regard these covariate info as measured BEFORE treatment info change (see rule b above). Alternatively (sensitivity analyses), adapt rule a and b to regard them as measured AFTER treatment info change
+
+fn_assign_dynamic_tu_cov <- function(data, 
+                                     patient_id_col,
+                                     variable_col, 
+                                     date_col, 
+                                     treat_date_col,
+                                     month_col,
+                                     start_date_col,
+                                     end_date_col) {
+  # Capture column names
+  patient_id_col <- rlang::ensym(patient_id_col)
+  variable_col <- rlang::ensym(variable_col)
+  date_col <- rlang::ensym(date_col)
+  treat_col <- rlang::ensym(treat_date_col)
+  month_col <- rlang::ensym(month_col)
+  start_col <- rlang::ensym(start_date_col)
+  end_col <- rlang::ensym(end_date_col)
+  
+  data %>%
+    # Group by patient, month, and variable to handle multiple measurements of the same type within one month per person
+    group_by(!!patient_id_col, !!variable_col, !!month_col) %>%
+    arrange(!!date_col, .by_group = TRUE) %>%
+    
+    mutate(
+      time_diff_to_end = as.numeric(!!end_col - !!date_col),
+      time_diff_to_treat = as.numeric(!!date_col - !!treat_col)
+    ) %>%
+    
+    mutate(
+      # flag all (rows) that are in same interval as our treatment information change/update variable (cens_date_metfin_start_cont)
+      is_treat_month = case_when(
+        !is.na(!!treat_col) &
+          !!treat_col >= !!start_col & !!treat_col <= !!end_col &
+          !!date_col >= !!start_col & !!date_col <= !!end_col ~ TRUE,
+        TRUE ~ FALSE
+      )
+    ) %>%
+    
+    # Precompute groupwise minima to avoid rowwise min() warnings
+    mutate(
+      min_time_diff_to_end = suppressWarnings(min(abs(time_diff_to_end),   na.rm = TRUE)),
+      min_time_diff_to_treat = suppressWarnings(min(abs(time_diff_to_treat), na.rm = TRUE))
+    ) %>%
+    
+    mutate(
+      # rule (a)
+      is_treat_month_after_treat_move = case_when(
+        is_treat_month & !!date_col > !!treat_col &
+          abs(time_diff_to_end) == min_time_diff_to_end ~ TRUE,
+        TRUE ~ FALSE
+      ),
+      # rule (b)
+      is_treat_month_before_treat_keep = case_when(
+        is_treat_month & !!date_col <= !!treat_col &
+          abs(time_diff_to_treat) == min_time_diff_to_treat ~ TRUE,
+        TRUE ~ FALSE
+      ),
+      # rule (c)
+      is_not_treat_month_move = case_when(
+        !is_treat_month &
+          abs(time_diff_to_end) == min_time_diff_to_end ~ TRUE,
+        TRUE ~ FALSE
+      )
+    ) %>%
+    
+    ungroup() %>%
+    # discard all those that are not flagged as "MOVER" or "KEEPER"
+    filter(is_not_treat_month_move | is_treat_month_before_treat_keep | is_treat_month_after_treat_move) %>%
+    
+    mutate(
+      # shift the "MOVERS" to next month, keep the "KEEPERS" with the original month
+      new_month = case_when(
+        is_not_treat_month_move | is_treat_month_after_treat_move ~ (!!month_col) + 1,
+        TRUE ~ (!!month_col)
+      )
+    ) %>%
+    
+    group_by(!!patient_id_col, !!variable_col, new_month) %>%
+    # dealt with edge case (i): Due to the move, we now may have instances whereby we moved a "MOVER" one into a month with a "KEEPER" one.
+    # Use "arrange", so that TRUE values for is_cens_month_before_cens_keep come first and then keep only those ones ("KEEPER" beats "MOVER")
+    arrange(desc(is_treat_month_before_treat_keep)) %>%
+    slice(1) %>%
+    ungroup() %>%
+    
+    # Drop helper columns
+    select(-c(time_diff_to_end,
+              time_diff_to_treat,
+              min_time_diff_to_end,
+              min_time_diff_to_treat,
+              is_treat_month,
+              is_treat_month_after_treat_move,
+              is_treat_month_before_treat_keep,
+              is_not_treat_month_move))
+}

--- a/analysis/functions/fn_assign_stable_tu_cov.R
+++ b/analysis/functions/fn_assign_stable_tu_cov.R
@@ -1,0 +1,68 @@
+####
+# Custom-made function to add stable time-udpated covariates to person-interval data and adhere to specific rules:
+#### 
+# Rule a–c:
+## If covariate date is NA -> all intervals = 0
+## If covariate date < min follow-up start -> all intervals = 1
+## If covariate date > max follow-up end -> all intervals = 0
+
+# Rule d (during follow-up; covariate event not in same interval as treatment information change):
+## Mark 0 up to and including the interval of the event,
+## Then assign 1 from the next interval onwards (via lag(cummax())).
+
+# Rule e (during follow-up; covariate event in same interval as treatment information change):
+## If cov_date <= treat_date, then mark *current* interval as 1. Otherwise, keep as-is.
+
+fn_assign_stable_tu_cov <- function(df, date_vars, start_var, end_var, cens_date_var) {
+  
+  df_out <- df
+  
+  walk(date_vars, function(var) {
+    # create binary flagging variable, based on _date_ naming
+    bin_var <- str_replace(var, "_date_", "_bin_")
+    
+    df_out <<- df_out %>%
+      group_by(patient_id) %>%
+      arrange(.data[[start_var]], .by_group = TRUE) %>%
+      
+      mutate(
+        cov_date = .data[[var]],
+        min_start = min(.data[[start_var]], na.rm = TRUE),
+        max_end   = max(.data[[end_var]], na.rm = TRUE),
+        
+        # rules a–c
+        !!bin_var := case_when(
+          is.na(cov_date) ~ 0, 
+          cov_date < min_start ~ 1, 
+          cov_date > max_end   ~ 0, 
+          TRUE ~ NA_real_   
+        )
+      ) %>%
+      
+    # rule d
+    mutate(
+      event_here = ifelse(!is.na(cov_date) &
+                            cov_date >= .data[[start_var]] &
+                            cov_date <= .data[[end_var]], 1, 0),
+      
+      cov_flag_temp = dplyr::lag(cummax(event_here), default = 0),
+      
+      !!bin_var := ifelse(is.na(.data[[bin_var]]), cov_flag_temp, .data[[bin_var]])
+    ) %>%
+      
+    # rule e
+    mutate(
+      !!bin_var := case_when(
+        # covariate in same interval as censoring
+        !is.na(cov_date) & cov_date >= .data[[start_var]] & cov_date <= .data[[end_var]] &
+          !is.na(.data[[cens_date_var]]) & .data[[cens_date_var]] >= .data[[start_var]] & .data[[cens_date_var]] <= .data[[end_var]] &
+          cov_date <= .data[[cens_date_var]] ~ 1,  # if cov_date before or at censor date in same interval -> mark/overwrite current interval with 1
+        TRUE ~ .data[[bin_var]]
+      )
+    ) %>%
+      ungroup() %>%
+      select(-cov_date, -min_start, -max_end, -event_here, -cov_flag_temp)
+  })
+  
+  return(df_out)
+}

--- a/analysis/functions/fn_assign_treatment.R
+++ b/analysis/functions/fn_assign_treatment.R
@@ -1,0 +1,62 @@
+####
+# Custom-made function to add treatment to person-interval data
+## RULES:
+# a) if event date is not NA and happened before the minimum start date of all intervals of a person, then assign 1 (in corresponding flag variable) to all person-intervals
+# b) if event date is not NA and happened after the maximum end date of all intervals of a person, then assign 0 (in corresponding flag variable) to all person-intervals
+# c) if no event date is recorded (date variable == NA), then assign 0 (in corresponding flag variable) to all person-intervals (assuming no documentation = no event)
+# d) if event date happened during follow-up, then assign 1 (in corresponding flag variable) to corresponding person-interval, and 0 to all person-intervals before, and 1 to all person-intervals after (stable/time-fixed event)
+
+fn_assign_treatment <- function(df, date_vars, start_var, end_var) {
+  
+  df_out <- df
+  
+  walk(date_vars, function(var) {
+    # create binary flagging variable by replacing the _date_ with a corresponding _bin_
+    bin_var <- str_replace(var, "_date_", "_bin_")
+    
+    df_out <<- df_out %>%
+      group_by(patient_id) %>%
+      
+      mutate(
+        elig_date = {
+          # to be on the safe side if the entire variable is NA
+          na_value <- if (is.numeric(.data[[var]])) {
+            NA_real_
+          } else if (inherits(.data[[var]], "Date")) {
+            as.Date(NA)
+          } else {
+            NA
+          }
+          if (all(is.na(.data[[var]]))) na_value else first(na.omit(.data[[var]]))
+        },
+        !!bin_var := case_when(
+          is.na(elig_date) ~ 0,
+          elig_date < min(.data[[start_var]], na.rm = TRUE) ~ 1,
+          elig_date >= min(.data[[start_var]], na.rm = TRUE) & elig_date <= max(.data[[end_var]], na.rm = TRUE) ~ NA_real_,  # assign NA for now, deal with it in a second step
+          elig_date > max(.data[[end_var]], na.rm = TRUE) ~ 0
+        )
+      ) %>% 
+      mutate(
+        !!bin_var := ifelse(
+          is.na(.data[[bin_var]]),
+          ifelse(
+            elig_date >= .data[[start_var]] & elig_date <= .data[[end_var]],
+            1,
+            NA_real_
+          ),
+          .data[[bin_var]]
+        )
+      ) %>%
+      arrange(.data[[start_var]]) %>%
+      mutate(
+        !!bin_var := zoo::na.locf(.data[[bin_var]], na.rm = FALSE), # assign 1 forward
+        !!bin_var := replace_na(.data[[bin_var]], 0) # assign 0 backwards
+      ) %>%
+      ungroup() %>%
+      select(-elig_date)
+  })
+  
+  return(df_out)
+}
+
+

--- a/analysis/functions/fn_expand_intervals.R
+++ b/analysis/functions/fn_expand_intervals.R
@@ -1,0 +1,53 @@
+####
+# Custom-made function to expand a one-person per row dataset to a event-level dataset
+# Expand until first stopping event happens and assign calendar intervals (monthly or weekly)
+# Required packages (load in main script):
+# library(dplyr)
+# library(tidyr)
+# library(purrr)
+# library(rlang)
+# library(lubridate)
+# Or: library(tidyverse) & library(lubridate) & library(rlang) 
+
+fn_expand_intervals <- function(data, start_date_variable, stop_date_columns, studyend_date, interval_type = c("week", "month")) {
+  interval_type <- match.arg(interval_type)  # Ensure only valid options are chosen
+  
+  data %>%
+    rowwise() %>%
+    mutate(
+      start_date = if (is.character(start_date_variable)) .data[[start_date_variable]] else start_date_variable,
+      stop_date = pmin(!!!syms(stop_date_columns), studyend_date, na.rm = TRUE)
+    ) %>%
+    ungroup() %>%
+    
+    # Create list of (start, stop) pairs for each interval
+    mutate(intervals_list = map2(start_date, stop_date, ~ {
+      current_start <- .x
+      intervals <- list()
+      while (current_start <= .y) {
+        next_start <- if (interval_type == "week") current_start + weeks(1) else current_start %m+% months(1)
+        current_stop <- next_start - days(1)
+        if (current_stop > .y) current_stop <- .y
+        intervals <- append(intervals, list(list(start = current_start, stop = current_stop)))
+        current_start <- next_start
+      }
+      intervals
+    })) %>%
+    
+    # Unnest the list into rows and widen start/stop
+    unnest(intervals_list) %>%
+    unnest_wider(intervals_list, names_sep = "_") %>%
+    
+    group_by(patient_id) %>%
+    mutate(
+      interval = row_number() - 1 # Start interval count at 0
+    ) %>%
+    ungroup() %>%
+    
+    # Rename the interval columns
+    rename(
+      !!paste0("start_date_", interval_type) := intervals_list_start,
+      !!paste0("end_date_", interval_type) := intervals_list_stop,
+      !!interval_type := interval
+    )
+}

--- a/analysis/functions/fn_smd_after.R
+++ b/analysis/functions/fn_smd_after.R
@@ -1,0 +1,64 @@
+####
+# Custom-made function to calculate mean difference or/and standardized mean difference AFTER weighting
+# In case both groups are NA (e.g. as in dummy data): skip
+# If no levels exist or smd_levels is empty: set to NA.
+
+fn_smd_after <- function(x, w_treat_0, w_treat_1) {
+  # Subsetting the data based on the variable name (x)
+  t0 <- treat_b0[[x]]
+  t1 <- treat_b1[[x]]
+  w0 <- w_treat_0  # Weights for the control group
+  w1 <- w_treat_1  # Weights for the treated group
+  
+  # Handle binary/logical variables
+  if (is.logical(t0) || is.logical(t1)) {
+    t0 <- factor(t0, levels = c(FALSE, TRUE))  # Convert the logicals to factors
+    t1 <- factor(t1, levels = c(FALSE, TRUE)) 
+  }
+  
+  # Handle missing data
+  if (all(is.na(t0)) || all(is.na(t1))) {
+    result <- c(var = x, type = "empty", smd = NA)
+  } else if (is.numeric(t0)) {
+    # Weighted Numeric: SMD
+    weighted_mean_t0 <- weighted.mean(t0, w0, na.rm = TRUE)
+    weighted_mean_t1 <- weighted.mean(t1, w1, na.rm = TRUE)
+    weighted_var_t0 <- sum(w0 * (t0 - weighted_mean_t0)^2, na.rm = TRUE) / sum(w0, na.rm = TRUE)
+    weighted_var_t1 <- sum(w1 * (t1 - weighted_mean_t1)^2, na.rm = TRUE) / sum(w1, na.rm = TRUE)
+    pooled_sd <- sqrt((weighted_var_t0 + weighted_var_t1) / 2)
+    smd <- (weighted_mean_t1 - weighted_mean_t0) / pooled_sd
+    result <- c(var = x, type = "numeric", smd = smd)
+    
+  } else if (is.factor(t0) || is.character(t0)) {
+    # Weighted Categorical: compute SMD per level, report max
+    levels_all <- union(levels(factor(t0)), levels(factor(t1)))
+    smd_levels <- c()
+    for (lvl in levels_all) {
+      p0 <- weighted.mean(t0 == lvl, w0, na.rm = TRUE)
+      p1 <- weighted.mean(t1 == lvl, w1, na.rm = TRUE)
+      p_pool <- (p0 + p1) / 2
+      # Avoid divide by zero
+      if (p_pool == 0 || p_pool == 1) {
+        smd_lvl <- 0
+      } else {
+        smd_lvl <- (p1 - p0) / sqrt(p_pool * (1 - p_pool))
+      }
+      smd_levels <- c(smd_levels, smd_lvl)
+    }
+    if (length(smd_levels) == 0 || all(is.na(smd_levels))) {
+      max_smd <- NA
+    } else {
+      max_smd <- max(abs(smd_levels), na.rm = TRUE)
+    }
+    result <- c(var = x, type = "categorical", smd = max_smd)
+    
+  } else {
+    result <- c(var = x, type = "unknown", smd = NA)
+  }
+  
+  return(result)
+}
+
+
+
+

--- a/analysis/functions/fn_smd_before.R
+++ b/analysis/functions/fn_smd_before.R
@@ -1,0 +1,60 @@
+####
+# Custom-made function to calculate mean difference or/and standardized mean difference BEFORE any weighting
+# In case both groups are NA (e.g. as in dummy data): skip
+# If no levels exist or smd_levels is empty: set to NA.
+
+fn_smd_before <- function(x) {
+  t0 <- treat_b0[[x]]
+  t1 <- treat_b1[[x]]
+  
+  # Handle binary/logical variables
+  if (is.logical(t0) || is.logical(t1)) {
+    t0 <- factor(t0, levels = c(FALSE, TRUE))  # Convert the logicals to factors
+    t1 <- factor(t1, levels = c(FALSE, TRUE))  # Convert the logicals to factors
+  }
+  
+  # Checks if either t0 or t1 contains ONLY missing values; if so, don't calculate SMD
+  if (all(is.na(t0)) || all(is.na(t1))) {
+    result <- c(var = x, type = "empty", smd = NA)
+    
+  } else if (is.numeric(t0)) {
+    # Numeric: SMD
+    pooled_sd <- sqrt((var(t0, na.rm = TRUE) + var(t1, na.rm = TRUE)) / 2)
+    smd <- (mean(t1, na.rm = TRUE) - mean(t0, na.rm = TRUE)) / pooled_sd # divided by pooled standard deviation to get SMD
+    result <- c(var = x, type = "numeric", smd = smd)
+    
+  } else if (is.factor(t0) || is.character(t0)) {
+    # Categorical/Factor or Binary/Logical
+    # Categorical: compute SMD for each level, report max! p_pool: the average of p0 and p1.
+    levels_all <- union(levels(factor(t0)), levels(factor(t1)))
+    smd_levels <- c()
+    for (lvl in levels_all) {
+      p0 <- mean(t0 == lvl, na.rm = TRUE)
+      p1 <- mean(t1 == lvl, na.rm = TRUE)
+      p_pool <- (p0 + p1) / 2
+      # Avoid divide by zero (-> SMD set to 0)
+      if (p_pool == 0 || p_pool == 1) {
+        smd_lvl <- 0
+      } else {
+        smd_lvl <- (p1 - p0) / sqrt(p_pool * (1 - p_pool)) # otherwise use formula
+      }
+      smd_levels <- c(smd_levels, smd_lvl)
+    }
+    # any SMD calculated for each level of the categorical variable?
+    if (length(smd_levels) == 0 || all(is.na(smd_levels))) {
+      # If no valid SMD values exist (either because the vector is empty or all values are NA), then assign NA to max_smd...
+      max_smd <- NA
+    } else {
+      # ...otherwise use max
+      max_smd <- max(abs(smd_levels), na.rm = TRUE)
+    }
+    result <- c(var = x, type = "categorical", smd = max_smd)
+    
+  } else {
+    result <- c(var = x, type = "unknown", smd = NA)
+  }
+  
+  return(result)
+}
+
+

--- a/project.yaml
+++ b/project.yaml
@@ -474,3 +474,31 @@ actions:
       moderately_sensitive:
         model_output: output/make_output/results_cox.csv
         model_output_midpoint6: output/make_output/results_cox_midpoint6.csv
+  
+  PPA_01_add_intervals:
+    run: r:latest analysis/PPA_01_add_intervals.R
+    needs:
+    - data_process
+    outputs:
+      highly_sensitive:
+        dataset: output/data/df_months.arrow
+
+  PPA_02_add_events:
+    run: r:latest analysis/PPA_02_add_events.R
+    needs:
+    - PPA_01_add_intervals
+    - data_process_ppa
+    outputs:
+      highly_sensitive:
+        dataset1: output/data/df_months_severecovid.arrow
+        dataset2: output/data/df_months_covid_event.arrow
+        dataset3: output/data/df_months_longcovid.arrow
+
+  PPA_03_pooled_log_reg:
+    run: r:latest analysis/PPA_03_pooled_log_reg.R
+    needs:
+    - PPA_02_add_events
+    outputs:
+      moderately_sensitive:
+        csv: output/te/pooled_log_reg/*.csv
+        plots: output/te/pooled_log_reg/*.png


### PR DESCRIPTION
PR for the per protocol analysis, according to protocol: "We estimate the per-protocol effect of starting metformin monotherapy vs never starting any metformin on the primary outcome by artificially censoring individuals deviating from their assigned treatment strategy (i.e. starting metformin in control group) and using inverse probability of censoring weights to account for this informative censoring. We use the same covariates as for the primary outcome model to estimate the weights, but included time-updated covariate information. We calculate risk ratios with 95% confidence intervals, derived from pooled logistic regression, based on discretized longitudinal time data."

This PR contains the following: 

`PPA_01_add_intervals.R`: 
- 1. Import pre-processed data of a one-person-per-row dataset of eligible participants (data_processed.arrow)
- 2. Restructure the one-person-per-row data into a multiple-event-per-person long format dataset, with time intervals as per study protocol, using the function `fn_expand_intervals.R`

`PPA_02_add_events.R`: 
- 1. Import multiple-event-per-person long format dataset (df_months, which originates from data_processed.arrow)
- 2. Import the separate dataset with stable and dynamic time-updated covariates needed for the per-protocol analysis (data_processed_ppa.arrow -> df_ppa)
- 3. Assign treatment to df_months, using `fn_assign_treatment.R`
- 4. Merge the stable time-updated (first-ever, constant) covariates from df_ppa to df_months. To test edge cases, further adapt dummy data
- 5. Assign the stable time-updated (first-ever, constant) in df_months, using `fn_assign_stable_tu_cov.R`
- 6. Reformatting of the dynamic time-updated covariates in a long-format df_ppa, before merging to df_months. To test edge cases, further adapt dummy data.
- 7. Merge and assign the dynamic time-updated covariates covariates from df_ppa to df_months, using `fn_assign_dynamic_tu_cov.R`
- 8. Fill up the Swiss cheese and reassign the lipid ratio and categorical variables for numeric variables
- 9. Assign and shift outcomes, competing, and censoring events, using `fn_add_and_shift_out_comp_cens_events.R`

`PPA_03_pooled_log_reg.R`: 
- Estimate adjusted but marginal risks per group, risk differences, risk ratios using inverse probability weighting (IPW) and then standardise. Use bootstrapping for 95% CI.
- Create marginal parametric cumulative incidence (risk) curves incl. 95% CI (via bootstrapping)