### PR TITLE
Make PPA output disclosure safe

### DIFF
--- a/analysis/PPA_03_pooled_log_reg.R
+++ b/analysis/PPA_03_pooled_log_reg.R
@@ -22,6 +22,7 @@ source(here::here("analysis", "functions", "fn_truncate_by_percentile.R"))
 source(here::here("analysis", "functions", "fn_standardize_risks.R"))
 source(here::here("analysis", "functions", "fn_extract_ci_boot.R"))
 source(here::here("analysis", "covariates.R"))
+source(here::here("analysis", "functions", "utility.R"))
 
 
 # Parse command line arguments --------------------------------------------
@@ -613,7 +614,7 @@ te_iptw_ipcw_rd_rr_withCI <- function(data, indices, data_full, covariates_tv_na
       return(rep(NA, length(c(results_std$graph_data$risk0, results_std$graph_data$risk1, results_std$graph_data$rd, results_std$graph_data$rr))))
     } else {
       # If not, return NA values of a default length
-      # return 4 * (K + 1), not 4 * K, see explanation below re bootstrap object format
+      # return 4 * (K + 1), not 4 * K, see explanation below
       return(rep(NA, 4 * (K + 1))) # 4 metrics (risk0, risk1, rd, rr) for K time points
     }
   })
@@ -636,7 +637,7 @@ te_iptw_ipcw_rd_rr_withCI_severecovid_boot <- boot(
 cat("Number of failed bootstrap samples:", boot_failures, "\n")
 
 ### My bootstrap object contains:
-cat(sprintf("   Number of statistics per sample (risk0, risk1, RR, RD): %d\n", 
+cat(sprintf("Number of statistics per sample (risk0, risk1, RR, RD): %d\n", 
             ncol(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t)))
 # 100 values per bootstrap sample, i.e., 4 * (K + 1) values per bootstrap sample = 100 for K = 24
 # Indices: risk0 (1-25), risk1 (26-50), rd (51-75), rr (76-100), i.e., risk0 (1 to K+1), risk1 (K+2 to 2*(K+1)), rd (2*(K+1)+1 to 3*(K+1)), rr (3*(K+1)+1 to 4*(K+1))
@@ -646,65 +647,56 @@ cat(sprintf("   Number of statistics per sample (risk0, risk1, RR, RD): %d\n",
 # Row 25: month = 23 (time_0 = 24)
 # So there are K+1 = 25 rows (1 zero_row + 24 monthly rows for months 0 to 23). The final month of interest is K-1 = 23, which sits at row index K+1 = 25 within each block.
 
-### Extract the final time point only
-# Indices: K+1 is the last row of each block (zero row at index 1, month K-1 at index K+1)
-indices <- c(
-  K + 1, # risk0 at month K-1
-  (K + 1) + (K + 1), # risk1 at month K-1
-  (K + 1) + 2 * (K + 1), # rd at month K-1
-  (K + 1) + 3 * (K + 1)  # rr at month K-1
-)
-te_plr_iptw_ipcw_severecovid_boot_tbl <- data.frame(
-  Measure = c("Risk Control", "Risk Treatment", "Risk Difference", "Risk Ratio"),
-  # Pull from rounded point estimate, not t0 (which is unrounded)
-  Estimate_original = c(
-    cum_risk_treat_ltfu_comp_severecovid$final_risk0,
-    cum_risk_treat_ltfu_comp_severecovid$final_risk1,
-    cum_risk_treat_ltfu_comp_severecovid$final_rd,
-    cum_risk_treat_ltfu_comp_severecovid$final_rr
-  ),
-  Estimate_boot = colMeans(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, indices], na.rm = TRUE),
-  Lower_CI = sapply(indices, function(i) fn_extract_ci_boot(te_iptw_ipcw_rd_rr_withCI_severecovid_boot, i)[1]),
-  Upper_CI = sapply(indices, function(i) fn_extract_ci_boot(te_iptw_ipcw_rd_rr_withCI_severecovid_boot, i)[2])
-)
-
-### Extract all time points to build the risk table for the cum risk graph
-risk_graph <- data.frame(
-  time = 0:K,
-  mean.0 = numeric(K+1),
-  ll.0 = numeric(K+1),
-  ul.0 = numeric(K+1),
-  mean.1 = numeric(K+1),
-  ll.1 = numeric(K+1),
-  ul.1 = numeric(K+1)
-)
-
-# Calculate the mean and confidence intervals
+### Extract the risks and RR and RD for all time points
 mean_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, mean, na.rm = TRUE) # Mean for control group (first half contains risk0) 1:25 correctly extracts all 25 values (months 0-23) for control
 mean_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, mean, na.rm = TRUE) # Mean for treatment group (second half contains risk1) 26:50 correctly extracts all 25 values (months 0-23) for intervention
 
 ll_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, function(x) quantile(x, 0.025, na.rm = TRUE))
 ul_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, function(x) quantile(x, 0.975, na.rm = TRUE))
-
 ll_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, function(x) quantile(x, 0.025, na.rm = TRUE))
 ul_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, function(x) quantile(x, 0.975, na.rm = TRUE))
 
-risk_graph$mean.0 <- mean_risk0
-risk_graph$ll.0 <- ll_risk0
-risk_graph$ul.0 <- ul_risk0
-risk_graph$mean.1 <- mean_risk1
-risk_graph$ll.1 <- ll_risk1
-risk_graph$ul.1 <- ul_risk1
+mean_rd <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (2*(K+1)+1):(3*(K+1))], 2, mean, na.rm = TRUE)
+mean_rr <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (3*(K+1)+1):(4*(K+1))], 2, mean, na.rm = TRUE)
+
+ll_rd <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (2*(K+1)+1):(3*(K+1))], 2, function(x) quantile(x, 0.025, na.rm = TRUE))
+ul_rd <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (2*(K+1)+1):(3*(K+1))], 2, function(x) quantile(x, 0.975, na.rm = TRUE))
+ll_rr <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (3*(K+1)+1):(4*(K+1))], 2, function(x) quantile(x, 0.025, na.rm = TRUE))
+ul_rr <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (3*(K+1)+1):(4*(K+1))], 2, function(x) quantile(x, 0.975, na.rm = TRUE))
+
+# Single unified output table
+# Risks (mean.0, mean.1) and their CIs are rounded via fn_round_prop so that reviewers can verify against denom that no proportion masks a small count.
+# fn_round_prop: Apply fn_roundmid_any, then divide again => consistent with the rounding approach applied to point estimate curves in fn_standardize_risks()
+# RD and RR and their CIs are left unrounded since they are derived contrasts
+denom_rounded <- fn_roundmid_any(length(unique(df_months_severecovid$patient_id)), to = threshold)
+risk_graph <- data.frame(
+  time = 0:K,
+  denom_midpoint6 = denom_rounded,
+  mean.0_midpoint6 = fn_round_prop(mean_risk0),
+  ll.0_midpoint6 = fn_round_prop(ll_risk0),
+  ul.0_midpoint6 = fn_round_prop(ul_risk0),
+  mean.1_midpoint6 = fn_round_prop(mean_risk1),
+  ll.1_midpoint6 = fn_round_prop(ll_risk1),
+  ul.1_midpoint6 = fn_round_prop(ul_risk1),
+  mean.rd = mean_rd,
+  ll.rd = ll_rd,
+  ul.rd = ul_rd,
+  mean.rr = mean_rr,
+  ll.rr = ll_rr,
+  ul.rr = ul_rr,
+  orig_risk.0_midpoint6 = cum_risk_treat_ltfu_comp_severecovid$graph_data$risk0,
+  orig_risk.1_midpoint6 = cum_risk_treat_ltfu_comp_severecovid$graph_data$risk1
+)
 
 # Create plot
 plot_cum_risk_treat_ltfu_comp_ci_severecovid <- ggplot(risk_graph,
                                                       aes(x=time)) +
-  geom_line(aes(y = mean.1, # create line for intervention group
+  geom_line(aes(y = mean.1_midpoint6, # create line for intervention group
                 color = "Metformin"), linewidth = 1.5) +
-  geom_ribbon(aes(ymin = ll.1, ymax = ul.1, fill = "Metformin"), alpha = 0.4) +
-  geom_line(aes(y = mean.0, # create line for control group
+  geom_ribbon(aes(ymin = ll.1_midpoint6, ymax = ul.1_midpoint6, fill = "Metformin"), alpha = 0.4) +
+  geom_line(aes(y = mean.0_midpoint6, # create line for control group
                 color = "No Metformin"), linewidth = 1.5) +
-  geom_ribbon(aes(ymin = ll.0, ymax = ul.0, fill = "No Metformin"), alpha=0.4) +
+  geom_ribbon(aes(ymin = ll.0_midpoint6, ymax = ul.0_midpoint6, fill = "No Metformin"), alpha=0.4) +
   xlab("Months") +
   ylab("Cumulative Incidence (%)") +
   theme_minimal()+
@@ -729,10 +721,6 @@ plot_cum_risk_treat_ltfu_comp_ci_severecovid <- ggplot(risk_graph,
 
 # Save output -------------------------------------------------------------
 print('Save output')
-# Treatment effect (risk) estimates at 24 months, once with interaction and once without (to mirror Cox), depending on terminal args
-write.csv(te_plr_iptw_ipcw_severecovid_boot_tbl, 
-          file = here::here("output", "te", "pooled_log_reg", 
-                            paste0("te_plr_iptw_ipcw_severecovid_boot_tbl", output_suffix, ".csv")))
 # Marginal parametric cumulative incidence (risk) curves from plr models, first two only with point estimates, last one including 95% CI (from bootstrap)
 ggsave(filename = here::here("output", "te", "pooled_log_reg", 
                              paste0("plot_cum_risk_treat_severecovid", output_suffix, ".png")), 
@@ -743,10 +731,10 @@ ggsave(filename = here::here("output", "te", "pooled_log_reg",
 ggsave(filename = here::here("output", "te", "pooled_log_reg", 
                              paste0("plot_cum_risk_treat_ltfu_comp_ci_severecovid", output_suffix, ".png")), 
        plot_cum_risk_treat_ltfu_comp_ci_severecovid, width = 20, height = 20, units = "cm")
-# Save disclosure-safe graph_data for OpenSAFELY output checkers
-write.csv(cum_risk_treat_ltfu_comp_severecovid$graph_data,
+# Disclosure-safe dataset, from which we can read out the final 24-month results, too
+write.csv(risk_graph,
           file = here::here("output", "te", "pooled_log_reg",
-                            paste0("cum_risk_treat_ltfu_comp_severecovid", output_suffix, ".csv")),
+                            paste0("cum_risk_treat_ltfu_comp_ci_severecovid", output_suffix, ".csv")),
           row.names = FALSE)
 # Censoring plots and underlying data
 ggsave(filename = here::here("output", "te", "pooled_log_reg", "plot_censoring_ltfu.png"), plot_censoring_ltfu, width = 20, height = 20, units = "cm")

--- a/analysis/PPA_03_pooled_log_reg.R
+++ b/analysis/PPA_03_pooled_log_reg.R
@@ -84,6 +84,8 @@ source(here::here("analysis", "metadates.R"))
 study_dates <- lapply(study_dates, function(x) as.Date(x))
 studyend_date <- as.Date(study_dates$studyend_date, format = "%Y-%m-%d")
 
+# Define redaction threshold ----------------------------------------------
+threshold <- 6
 
 # Add splines -------------------------------------------------------------
 print('Add splines')
@@ -195,7 +197,9 @@ cum_risk_treat_severecovid <- fn_standardize_risks(
   model = treat.severecovid,
   group_col = "exp_bin_treat",
   time_col = "month",
-  patient_id_col = "patient_id"
+  patient_id_col = "patient_id",
+  min_count = threshold,
+  apply_rounding = TRUE
 )
 
 
@@ -396,12 +400,14 @@ cum_risk_treat_ltfu_comp_severecovid <- fn_standardize_risks(
   model = severecovid.treat.ltfu.comp,
   group_col = "exp_bin_treat",
   time_col = "month",
-  patient_id_col = "patient_id"
+  patient_id_col = "patient_id",
+  min_count = threshold,
+  apply_rounding = TRUE
 )
 
 ## Construct marginal parametric cumulative incidence (risk) curves (without CIs) -------
 print('Adjust additionally for time-varying LTFU and competing risk: Plot')
-plot_cum_risk_treat_ltfu_severecovid <- ggplot(cum_risk_treat_ltfu_comp_severecovid$graph_data,
+plot_cum_risk_treat_ltfu_comp_severecovid <- ggplot(cum_risk_treat_ltfu_comp_severecovid$graph_data,
                                                    aes(x=time_0, y=risk)) + 
   geom_line(aes(y = risk1, 
                 color = "Metformin"), linewidth = 1.5) +
@@ -591,7 +597,9 @@ te_iptw_ipcw_rd_rr_withCI <- function(data, indices, data_full, covariates_tv_na
       model = severecovid.treat.ltfu.comp,
       group_col = "exp_bin_treat",
       time_col = "month",
-      patient_id_col = "boot_patient_id"
+      patient_id_col = "boot_patient_id",
+      min_count = threshold,
+      apply_rounding = FALSE
     )
     
     return(c(results_std$graph_data$risk0, results_std$graph_data$risk1, results_std$graph_data$rd, results_std$graph_data$rr))
@@ -605,7 +613,8 @@ te_iptw_ipcw_rd_rr_withCI <- function(data, indices, data_full, covariates_tv_na
       return(rep(NA, length(c(results_std$graph_data$risk0, results_std$graph_data$risk1, results_std$graph_data$rd, results_std$graph_data$rr))))
     } else {
       # If not, return NA values of a default length
-      return(rep(NA, 4 * K)) # 4 metrics (risk0, risk1, rd, rr) for K time points
+      # return 4 * (K + 1), not 4 * K, see explanation below re bootstrap object format
+      return(rep(NA, 4 * (K + 1))) # 4 metrics (risk0, risk1, rd, rr) for K time points
     }
   })
 }
@@ -629,24 +638,31 @@ cat("Number of failed bootstrap samples:", boot_failures, "\n")
 ### My bootstrap object contains:
 cat(sprintf("   Number of statistics per sample (risk0, risk1, RR, RD): %d\n", 
             ncol(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t)))
-# 100 values per bootstrap sample
-# Indices: risk0 (1-25), risk1 (26-50), rd (51-75), rr (76-100)
-# the final month (23) is at position 24 in the vectors
-# Row 1: month = 0 (zero row, time_0 = 0)
-# Row 2: month = 0 (time_0 = 1)
+# 100 values per bootstrap sample, i.e., 4 * (K + 1) values per bootstrap sample = 100 for K = 24
+# Indices: risk0 (1-25), risk1 (26-50), rd (51-75), rr (76-100), i.e., risk0 (1 to K+1), risk1 (K+2 to 2*(K+1)), rd (2*(K+1)+1 to 3*(K+1)), rr (3*(K+1)+1 to 4*(K+1))
+# Row 1: month = 0 (zero row, time_0 = 1; from zero_row, see fn_standardize_risks)
+# Row 2: month = 0 (time_0 = 1; from risk_summary, see fn_standardize_risks)
 # Row 3: month = 1 (time_0 = 2)
+# Row 25: month = 23 (time_0 = 24)
+# So there are K+1 = 25 rows (1 zero_row + 24 monthly rows for months 0 to 23). The final month of interest is K-1 = 23, which sits at row index K+1 = 25 within each block.
 
 ### Extract the final time point only
-# Indices
+# Indices: K+1 is the last row of each block (zero row at index 1, month K-1 at index K+1)
 indices <- c(
-  K, # risk0 at month 23 (index 24)
-  K + (K + 1), # risk1 at month 23 (index 49)
-  K + 2 * (K + 1), # rd at month 23 (index 74)
-  K + 3 * (K + 1) # rr at month 23 (index 99)
+  K + 1, # risk0 at month K-1
+  (K + 1) + (K + 1), # risk1 at month K-1
+  (K + 1) + 2 * (K + 1), # rd at month K-1
+  (K + 1) + 3 * (K + 1)  # rr at month K-1
 )
 te_plr_iptw_ipcw_severecovid_boot_tbl <- data.frame(
   Measure = c("Risk Control", "Risk Treatment", "Risk Difference", "Risk Ratio"),
-  Estimate_original = te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t0[indices],
+  # Pull from rounded point estimate, not t0 (which is unrounded)
+  Estimate_original = c(
+    cum_risk_treat_ltfu_comp_severecovid$final_risk0,
+    cum_risk_treat_ltfu_comp_severecovid$final_risk1,
+    cum_risk_treat_ltfu_comp_severecovid$final_rd,
+    cum_risk_treat_ltfu_comp_severecovid$final_rr
+  ),
   Estimate_boot = colMeans(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, indices], na.rm = TRUE),
   Lower_CI = sapply(indices, function(i) fn_extract_ci_boot(te_iptw_ipcw_rd_rr_withCI_severecovid_boot, i)[1]),
   Upper_CI = sapply(indices, function(i) fn_extract_ci_boot(te_iptw_ipcw_rd_rr_withCI_severecovid_boot, i)[2])
@@ -664,14 +680,14 @@ risk_graph <- data.frame(
 )
 
 # Calculate the mean and confidence intervals
-mean_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, mean) # Mean for control group (first half contains risk0) 1:25 correctly extracts all 25 values (months 0-23) for control
-mean_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, mean) # Mean for treatment group (second half contains risk1) 26:50 correctly extracts all 25 values (months 0-23) for intervention
+mean_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, mean, na.rm = TRUE) # Mean for control group (first half contains risk0) 1:25 correctly extracts all 25 values (months 0-23) for control
+mean_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, mean, na.rm = TRUE) # Mean for treatment group (second half contains risk1) 26:50 correctly extracts all 25 values (months 0-23) for intervention
 
-ll_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, function(x) quantile(x, 0.025))
-ul_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, function(x) quantile(x, 0.975))
+ll_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, function(x) quantile(x, 0.025, na.rm = TRUE))
+ul_risk0 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, 1:(K+1)], 2, function(x) quantile(x, 0.975, na.rm = TRUE))
 
-ll_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, function(x) quantile(x, 0.025))
-ul_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, function(x) quantile(x, 0.975))
+ll_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, function(x) quantile(x, 0.025, na.rm = TRUE))
+ul_risk1 <- apply(te_iptw_ipcw_rd_rr_withCI_severecovid_boot$t[, (K+2):(2*(K+1))], 2, function(x) quantile(x, 0.975, na.rm = TRUE))
 
 risk_graph$mean.0 <- mean_risk0
 risk_graph$ll.0 <- ll_risk0
@@ -722,11 +738,16 @@ ggsave(filename = here::here("output", "te", "pooled_log_reg",
                              paste0("plot_cum_risk_treat_severecovid", output_suffix, ".png")), 
        plot_cum_risk_treat_severecovid, width = 20, height = 20, units = "cm")
 ggsave(filename = here::here("output", "te", "pooled_log_reg", 
-                             paste0("plot_cum_risk_treat_ltfu_severecovid", output_suffix, ".png")), 
-       plot_cum_risk_treat_ltfu_severecovid, width = 20, height = 20, units = "cm")
+                             paste0("plot_cum_risk_treat_ltfu_comp_severecovid", output_suffix, ".png")), 
+       plot_cum_risk_treat_ltfu_comp_severecovid, width = 20, height = 20, units = "cm")
 ggsave(filename = here::here("output", "te", "pooled_log_reg", 
                              paste0("plot_cum_risk_treat_ltfu_comp_ci_severecovid", output_suffix, ".png")), 
        plot_cum_risk_treat_ltfu_comp_ci_severecovid, width = 20, height = 20, units = "cm")
+# Save disclosure-safe graph_data for OpenSAFELY output checkers
+write.csv(cum_risk_treat_ltfu_comp_severecovid$graph_data,
+          file = here::here("output", "te", "pooled_log_reg",
+                            paste0("cum_risk_treat_ltfu_comp_severecovid", output_suffix, ".csv")),
+          row.names = FALSE)
 # Censoring plots and underlying data
 ggsave(filename = here::here("output", "te", "pooled_log_reg", "plot_censoring_ltfu.png"), plot_censoring_ltfu, width = 20, height = 20, units = "cm")
 write.csv(censoring_ltfu_rates, file = here::here("output", "te", "pooled_log_reg", "censoring_ltfu_rates.csv"))

--- a/analysis/functions/fn_standardize_risks.R
+++ b/analysis/functions/fn_standardize_risks.R
@@ -1,5 +1,5 @@
 ###
-# Custom-made function to perform standardization/marginalization
+# Custom-made function to perform disclosure-safe standardization/marginalization
 ###
 
 # Args:
@@ -9,15 +9,22 @@
 #   group_col: A string specifying the name of the group name
 #   time_col: A string specifying the name of the time column | CAVE: We model time as time and time_sqr. Needs to be double-checked if in line with analysis approach.
 #   patient_id_col: The name of the patient ID column to group by. -> esp. important for use in bootstrap!
+#   min_count: disclosure threshold, current OpenSAFELY default is 6
+#   apply_rounding: Logical. If TRUE (default), applies fn_roundmid_any disclosure control to cumulative numerators and denominator before computing cumulative incidence.
+#                   Set to FALSE (e.g. inside bootstrap to avoid adding artificial rounding noise to each replicate, which would inflate CI variance). In that case, rounding should only be applied to the point estimate from the original sample.
+
 # Returns:
 #   A list containing the final standardized risk data frame and the final
 #   risk difference (rd) and risk ratio (rr) estimates.
 # After binding:
-# Row 1: month = 0 (zero row, time_0 = 0)
-# Row 2: month = 0 (from risk_summary where time_0 = 1)
-# Row 3: month = 1 (from risk_summary where time_0 = 2)
+# Row 1: month = 0 (zero row, time_0 = 1; from zero_row, see fn_standardize_risks)
+# Row 2: month = 0 (time_0 = 1; from risk_summary, see fn_standardize_risks)
+# Row 3: month = 1 (time_0 = 2)
 
-fn_standardize_risks <- function(df, K, model, group_col = "exp_bin_treat", time_col = "month", patient_id_col = "patient_id") {
+# get fn_roundmid_any
+source(here::here("analysis", "functions", "utility.R"))
+
+fn_standardize_risks <- function(df, K, model, group_col = "exp_bin_treat", time_col = "month", patient_id_col = "patient_id", min_count = 6, apply_rounding = TRUE) {
   # Create a dataset with all time points for each individual under each treatment level
   # This sets up a "prediction" dataset where we can estimate outcomes for every patient at every time point under each treatment scenario.
   df_pred <- df %>%
@@ -66,27 +73,48 @@ fn_standardize_risks <- function(df, K, model, group_col = "exp_bin_treat", time
     ) %>%
     dplyr::ungroup()
   
+  # DISCLOSURE CONTROL
   # Get the mean risk in each treatment group at each time point
   # This aggregates the individual risks to get the standardized population-level risk.
+  
+  # N is fixed (same patients at every time point in g-computation)
+  N <- dplyr::n_distinct(df_pred[[patient_id_col]])
+  
   risk_summary <- df_pred %>%
     dplyr::group_by(!!rlang::sym(time_col)) %>%
     dplyr::summarise(
-      risk0 = mean(risk0),
-      risk1 = mean(risk1),
+      # Sum of individual predicted risks = "expected event" numerator
+      cml.event0 = sum(risk0),
+      cml.event1 = sum(risk1),
       .groups = "drop"
     ) %>%
-    # Edit data frame to reflect that risks are estimated at the END of each interval
-    dplyr::mutate(time_0 = .data[[time_col]] + 1)
+    dplyr::mutate(
+      # Apply midpoint rounding when producing the point estimate for release.
+      # When apply_rounding = FALSE (i.e. inside bootstrap), pass through raw values, to avoid adding artificial rounding noise to each replicate.
+      cml.event0.rounded = if (apply_rounding) fn_roundmid_any(cml.event0, to = min_count) else cml.event0,
+      cml.event1.rounded = if (apply_rounding) fn_roundmid_any(cml.event1, to = min_count) else cml.event1,
+      # Denominator: total N, rounded once (only meaningful for release output)
+      denom = if (apply_rounding) fn_roundmid_any(N, to = min_count) else N,
+      # Back-calculate cumulative incidence from (rounded) counts
+      risk0 = cml.event0.rounded / denom,
+      risk1 = cml.event1.rounded / denom,
+      # Edit data frame to reflect that risks are estimated at the END of each interval
+      time_0 = .data[[time_col]] + 1
+    )
   
   # add the initial zero row
   zero_row <- tibble::tibble(
     !!time_col := 0,
+    cml.event0.rounded = 0,
+    cml.event1.rounded = 0,
+    denom = if (apply_rounding) fn_roundmid_any(N, to = min_count) else N,
     risk0 = 0,
     risk1 = 0,
     time_0 = 1
   )
   
   # build the graph and calculate risk difference and risk ratio
+  # graph_data serves as both the release output (disclosure-safe when apply_rounding = TRUE) and the source for plotting. It contains rounded numerators and denominator so that OpenSAFELY output checkers can verify no percentage masks a small underlying count.
   graph <- dplyr::bind_rows(zero_row, risk_summary) %>%
     dplyr::mutate(
       rd = risk1 - risk0,
@@ -97,7 +125,7 @@ fn_standardize_risks <- function(df, K, model, group_col = "exp_bin_treat", time
   final_row <- graph %>% dplyr::filter(.data[[time_col]] == K - 1)
   
   return(list(
-    graph_data = graph,
+    graph_data = graph, # disclosure-safe output for graph building and release
     final_risk0 = final_row$risk0,
     final_risk1 = final_row$risk1,
     final_rd = final_row$rd,

--- a/analysis/functions/fn_standardize_risks.R
+++ b/analysis/functions/fn_standardize_risks.R
@@ -110,7 +110,9 @@ fn_standardize_risks <- function(df, K, model, group_col = "exp_bin_treat", time
     denom = if (apply_rounding) fn_roundmid_any(N, to = min_count) else N,
     risk0 = 0,
     risk1 = 0,
-    time_0 = 1
+    time_0 = 1,
+    cml.event0 = 0,
+    cml.event1 = 0
   )
   
   # build the graph and calculate risk difference and risk ratio
@@ -119,7 +121,12 @@ fn_standardize_risks <- function(df, K, model, group_col = "exp_bin_treat", time
     dplyr::mutate(
       rd = risk1 - risk0,
       rr = risk1 / risk0
-    )
+    ) 
+  
+  # Drop raw numerators if rounding is applied. When apply_rounding = FALSE, cml.event0/1 are already equal to cml.event0/1.rounded so this step is not 100% needed, but we keep them for internal consistency
+  if (apply_rounding) {
+    graph <- graph %>% dplyr::select(-cml.event0, -cml.event1)
+  }
   
   # extract final values at end of follow-up
   final_row <- graph %>% dplyr::filter(.data[[time_col]] == K - 1)

--- a/analysis/functions/utility.R
+++ b/analysis/functions/utility.R
@@ -13,3 +13,6 @@ fn_roundmid_any <- function(x, to=6){ # default is midpoint rounding to 6
   # centers on (integer) midpoint of the rounding points
   ceiling(x/to)*to - (floor(to/2)*(x!=0))
 }
+
+# Prop rounding function for redaction -----------------------------------------
+fn_round_prop <- function(x) fn_roundmid_any(x * denom_rounded, to = threshold) / denom_rounded


### PR DESCRIPTION
Branch to apply disclosure control to cumulative incidence curves/plot of the per protocol analysis obtained via pooled logistic regression.

I incorporated midpoint-6-rounding directly into `fn_standardize_risks.R`, i.e., round both denominator and numerator, then calculate cumulative risks, and contrasts (RR/RD) from rounded values. 
This works well outside the bootstrap, e.g. see `cum_risk_treat_ltfu_comp_severecovid`, with the additional argument `apply_rounding = TRUE` in `fn_standardize_risks`

However, inside the bootstrap, this is an issue since this would add artificial rounding noise to each replicate, which would inflate CI variance.
Hence, I use `apply_rounding = FALSE` in `fn_standardize_risks` within the bootstrap, then take the bootstrap output object `risk_graph` and apply midpoint 6 rounding (via `fn_round_prop`) to all estimates that are proportions (i.e. the cumulative risks over time and their 95% CI), but not the RR/RD (and their 95% CI), since `fn_round_prop` would not work and they are derived contrasts (disclosure-safe). 

I also updated the indexing to reflect updated `fn_standardize_risks.R` (see line 642).

I also simplified the output of the bootstrap by only outputting one larger `risk_graph` that incorporates all risk estimates and if we want e.g. the final 24-month risk, we can simply do a read out from `risk_graph`. 